### PR TITLE
google-http-client-jackson2 serializing added to comparison

### DIFF
--- a/BenchmarkDemo/app/build.gradle
+++ b/BenchmarkDemo/app/build.gradle
@@ -55,4 +55,9 @@ dependencies {
 
     // GSON library for comparison
     compile 'com.google.code.gson:gson:2.3.1'
+
+    // Google http client for comparison
+    compile('com.google.http-client:google-http-client-jackson2:1.20.0') {
+        exclude(group: 'org.apache.httpcomponents', module: 'httpclient')
+    }
 }

--- a/BenchmarkDemo/app/src/main/java/com/bluelinelabs/logansquare/demo/MainActivity.java
+++ b/BenchmarkDemo/app/src/main/java/com/bluelinelabs/logansquare/demo/MainActivity.java
@@ -9,12 +9,14 @@ import android.view.View.OnClickListener;
 
 import com.bluelinelabs.logansquare.LoganSquare;
 import com.bluelinelabs.logansquare.demo.model.Response;
+import com.bluelinelabs.logansquare.demo.parsetasks.GoogleHttpJackson2Parser;
 import com.bluelinelabs.logansquare.demo.parsetasks.GsonParser;
 import com.bluelinelabs.logansquare.demo.parsetasks.JacksonDatabindParser;
 import com.bluelinelabs.logansquare.demo.parsetasks.LoganSquareParser;
 import com.bluelinelabs.logansquare.demo.parsetasks.ParseResult;
 import com.bluelinelabs.logansquare.demo.parsetasks.Parser;
 import com.bluelinelabs.logansquare.demo.parsetasks.Parser.ParseListener;
+import com.bluelinelabs.logansquare.demo.serializetasks.GoogleHttpJackson2Serializer;
 import com.bluelinelabs.logansquare.demo.serializetasks.GsonSerializer;
 import com.bluelinelabs.logansquare.demo.serializetasks.JacksonDatabindSerializer;
 import com.bluelinelabs.logansquare.demo.serializetasks.LoganSquareSerializer;
@@ -64,7 +66,7 @@ public class MainActivity extends ActionBarActivity {
         mResponsesToSerialize = getResponsesToParse();
 
         mBarChart = (BarChart)findViewById(R.id.bar_chart);
-        mBarChart.setColumnTitles(new String[] {"GSON", "Jackson", "LoganSquare"});
+        mBarChart.setColumnTitles(new String[] {"GSON", "Jackson", "LoganSquare", "google-http-jackson2"});
 
         findViewById(R.id.btn_parse_tests).setOnClickListener(new OnClickListener() {
             @Override
@@ -93,6 +95,7 @@ public class MainActivity extends ActionBarActivity {
                 parsers.add(new GsonParser(mParseListener, jsonString, gson));
                 parsers.add(new JacksonDatabindParser(mParseListener, jsonString, objectMapper));
                 parsers.add(new LoganSquareParser(mParseListener, jsonString));
+                parsers.add(new GoogleHttpJackson2Parser(mParseListener, jsonString));
             }
         }
 
@@ -113,6 +116,7 @@ public class MainActivity extends ActionBarActivity {
                 serializers.add(new GsonSerializer(mSerializeListener, response, gson));
                 serializers.add(new JacksonDatabindSerializer(mSerializeListener, response, objectMapper));
                 serializers.add(new LoganSquareSerializer(mSerializeListener, response));
+                serializers.add(new GoogleHttpJackson2Serializer(mSerializeListener, response));
             }
         }
 
@@ -147,6 +151,8 @@ public class MainActivity extends ActionBarActivity {
             mBarChart.addTiming(section, 1, parseResult.runDuration / 1000f);
         } else if (parser instanceof LoganSquareParser) {
             mBarChart.addTiming(section, 2, parseResult.runDuration / 1000f);
+        } else if (parser instanceof GoogleHttpJackson2Parser) {
+            mBarChart.addTiming(section, 3, parseResult.runDuration / 1000f);
         }
     }
 
@@ -176,6 +182,8 @@ public class MainActivity extends ActionBarActivity {
             mBarChart.addTiming(section, 1, serializeResult.runDuration / 1000f);
         } else if (serializer instanceof LoganSquareSerializer) {
             mBarChart.addTiming(section, 2, serializeResult.runDuration / 1000f);
+        } else if (serializer instanceof GoogleHttpJackson2Serializer) {
+            mBarChart.addTiming(section, 3, serializeResult.runDuration / 1000f);
         }
     }
 

--- a/BenchmarkDemo/app/src/main/java/com/bluelinelabs/logansquare/demo/model/Friend.java
+++ b/BenchmarkDemo/app/src/main/java/com/bluelinelabs/logansquare/demo/model/Friend.java
@@ -2,13 +2,16 @@ package com.bluelinelabs.logansquare.demo.model;
 
 import com.bluelinelabs.logansquare.annotation.JsonField;
 import com.bluelinelabs.logansquare.annotation.JsonObject;
+import com.google.api.client.util.Key;
 
 @JsonObject
 public class Friend {
 
+    @Key
     @JsonField
     public int id;
 
+    @Key
     @JsonField
     public String name;
 }

--- a/BenchmarkDemo/app/src/main/java/com/bluelinelabs/logansquare/demo/model/Image.java
+++ b/BenchmarkDemo/app/src/main/java/com/bluelinelabs/logansquare/demo/model/Image.java
@@ -2,19 +2,24 @@ package com.bluelinelabs.logansquare.demo.model;
 
 import com.bluelinelabs.logansquare.annotation.JsonField;
 import com.bluelinelabs.logansquare.annotation.JsonObject;
+import com.google.api.client.util.Key;
 
 @JsonObject
 public class Image {
 
+    @Key
     @JsonField
     public String id;
 
+    @Key
     @JsonField
     public String format;
 
+    @Key
     @JsonField
     public String url;
 
+    @Key
     @JsonField
     public String description;
 

--- a/BenchmarkDemo/app/src/main/java/com/bluelinelabs/logansquare/demo/model/Name.java
+++ b/BenchmarkDemo/app/src/main/java/com/bluelinelabs/logansquare/demo/model/Name.java
@@ -2,13 +2,16 @@ package com.bluelinelabs.logansquare.demo.model;
 
 import com.bluelinelabs.logansquare.annotation.JsonField;
 import com.bluelinelabs.logansquare.annotation.JsonObject;
+import com.google.api.client.util.Key;
 
 @JsonObject
 public class Name {
 
+    @Key
     @JsonField
     public String first;
 
+    @Key
     @JsonField
     public String last;
 }

--- a/BenchmarkDemo/app/src/main/java/com/bluelinelabs/logansquare/demo/model/Response.java
+++ b/BenchmarkDemo/app/src/main/java/com/bluelinelabs/logansquare/demo/model/Response.java
@@ -3,6 +3,7 @@ package com.bluelinelabs.logansquare.demo.model;
 import com.bluelinelabs.logansquare.annotation.JsonField;
 import com.bluelinelabs.logansquare.annotation.JsonObject;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.api.client.util.Key;
 import com.google.gson.annotations.SerializedName;
 
 import java.util.List;
@@ -10,12 +11,15 @@ import java.util.List;
 @JsonObject
 public class Response {
 
+    @Key
     @JsonField
     public List<User> users;
 
+    @Key
     @JsonField
     public String status;
 
+    @Key("is_real_json") // Annotation needed for google http client
     @SerializedName("is_real_json") // Annotation needed for GSON
     @JsonProperty("is_real_json") // Annotation needed for Jackson Databind
     @JsonField(name = "is_real_json")

--- a/BenchmarkDemo/app/src/main/java/com/bluelinelabs/logansquare/demo/model/User.java
+++ b/BenchmarkDemo/app/src/main/java/com/bluelinelabs/logansquare/demo/model/User.java
@@ -3,6 +3,7 @@ package com.bluelinelabs.logansquare.demo.model;
 import com.bluelinelabs.logansquare.annotation.JsonField;
 import com.bluelinelabs.logansquare.annotation.JsonObject;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.api.client.util.Key;
 import com.google.gson.annotations.SerializedName;
 
 import java.util.List;
@@ -10,82 +11,105 @@ import java.util.List;
 @JsonObject
 public class User {
 
+    @Key("_id") // Annotation needed for google http client
     @SerializedName("_id") // Annotation needed for GSON
     @JsonProperty("_id")
     @JsonField(name = "_id")
     public String id;
 
+    @Key
     @JsonField
     public int index;
 
+    @Key
     @JsonField
     public String guid;
 
+    @Key("is_active") // Annotation needed for google http client
     @SerializedName("is_active") // Annotation needed for GSON
     @JsonProperty("is_active") // Annotation needed for Jackson Databind
     @JsonField(name = "is_active")
     public boolean isActive;
 
+    @Key
     @JsonField
     public String balance;
 
+    @Key("picture") // Annotation needed for google http client
     @SerializedName("picture") // Annotation needed for GSON
     @JsonProperty("picture") // Annotation needed for Jackson Databind
     @JsonField(name = "picture")
     public String pictureUrl;
 
+    @Key
     @JsonField
     public int age;
 
+    @Key
     @JsonField
     public Name name;
 
+    @Key
     @JsonField
     public String company;
 
+    @Key
     @JsonField
     public String email;
 
+    @Key
     @JsonField
     public String address;
 
+    @Key
     @JsonField
     public String about;
 
+    @Key
     @JsonField
     public String registered;
 
+    @Key
     @JsonField
     public double latitude;
 
+    @Key
     @JsonField
     public double longitude;
 
+    @Key
     @JsonField
     public List<String> tags;
 
+    @Key
     @JsonField
     public List<Integer> range;
 
+    @Key
     @JsonField
     public List<Friend> friends;
 
+    @Key
     @JsonField
     public List<Image> images;
 
+    @Key
     @JsonField
     public String greeting;
 
+    @Key("favorite_fruit") // Annotation needed for google http client
     @SerializedName("favorite_fruit") // Annotation needed for GSON
     @JsonProperty("favorite_fruit") // Annotation needed for Jackson Databind
     @JsonField(name = "favorite_fruit")
     public String favoriteFruit;
 
+    @Key("eye_color") // Annotation needed for google http client
     @SerializedName("eye_color") // Annotation needed for GSON
     @JsonProperty("eye_color") // Annotation needed for Jackson Databind
     @JsonField(name = "eye_color")
     public String eyeColor;
 
+    @Key
     @JsonField
     public String phone;
 }

--- a/BenchmarkDemo/app/src/main/java/com/bluelinelabs/logansquare/demo/parsetasks/GoogleHttpJackson2Parser.java
+++ b/BenchmarkDemo/app/src/main/java/com/bluelinelabs/logansquare/demo/parsetasks/GoogleHttpJackson2Parser.java
@@ -1,0 +1,31 @@
+package com.bluelinelabs.logansquare.demo.parsetasks;
+
+import com.bluelinelabs.logansquare.demo.model.Response;
+import com.google.api.client.json.JsonParser;
+import com.google.api.client.json.jackson2.JacksonFactory;
+
+public class GoogleHttpJackson2Parser extends Parser {
+
+    private JacksonFactory jacksonFactory;
+
+    public GoogleHttpJackson2Parser(ParseListener parseListener, String jsonString) {
+        super(parseListener, jsonString);
+
+        jacksonFactory = new JacksonFactory();
+    }
+
+    @Override
+    protected int parse(String json) {
+        try {
+            JsonParser jsonParser = jacksonFactory.createJsonParser(json);
+            Response response = jsonParser.parse(Response.class);
+            jsonParser.close();
+            return response.users.size();
+        } catch (Exception e) {
+            return 0;
+        } finally {
+            System.gc();
+        }
+    }
+
+}

--- a/BenchmarkDemo/app/src/main/java/com/bluelinelabs/logansquare/demo/serializetasks/GoogleHttpJackson2Serializer.java
+++ b/BenchmarkDemo/app/src/main/java/com/bluelinelabs/logansquare/demo/serializetasks/GoogleHttpJackson2Serializer.java
@@ -1,0 +1,34 @@
+package com.bluelinelabs.logansquare.demo.serializetasks;
+
+import com.bluelinelabs.logansquare.demo.model.Response;
+import com.google.api.client.json.JsonGenerator;
+import com.google.api.client.json.jackson2.JacksonFactory;
+
+import java.io.StringWriter;
+
+public class GoogleHttpJackson2Serializer extends Serializer {
+
+    private JacksonFactory jacksonFactory;
+
+    public GoogleHttpJackson2Serializer(SerializeListener parseListener, Response response) {
+        super(parseListener, response);
+
+        jacksonFactory = new JacksonFactory();
+    }
+
+    @Override
+    protected String serialize(Response response) {
+        try {
+            StringWriter writer = new StringWriter();
+            JsonGenerator jsonGenerator = jacksonFactory.createJsonGenerator(writer);
+            jsonGenerator.serialize(response);
+            jsonGenerator.flush();
+            jsonGenerator.close();
+            return writer.toString();
+        } catch (Exception e) {
+            return null;
+        } finally {
+            System.gc();
+        }
+    }
+}

--- a/BenchmarkDemo/app/src/main/java/com/bluelinelabs/logansquare/demo/widget/BarChart.java
+++ b/BenchmarkDemo/app/src/main/java/com/bluelinelabs/logansquare/demo/widget/BarChart.java
@@ -17,7 +17,7 @@ import java.util.List;
 public class BarChart extends View {
 
     private static final int SECTION_COUNT = 4;
-    private static final int COLUMNS_PER_SECTION = 3;
+    private static final int COLUMNS_PER_SECTION = 4;
 
     private final Section[] mSections = new Section[SECTION_COUNT];
     private final Rect mTextBounds = new Rect();
@@ -55,6 +55,9 @@ public class BarChart extends View {
 
         mPaints[2] = new Paint();
         mPaints[2].setColor(0xFFe9969c);
+
+        mPaints[3] = new Paint();
+        mPaints[3].setColor(0xFF969ce9);
 
         mTextPaint = new TextPaint();
         mTextPaint.setColor(0xFF555555);
@@ -155,7 +158,7 @@ public class BarChart extends View {
 
         public Section() {
             title = "";
-            columns = new Column[] {new Column(), new Column(), new Column()};
+            columns = new Column[] {new Column(), new Column(), new Column(), new Column() };
         }
     }
 


### PR DESCRIPTION
Hello! Nice library! And it is cool that you already have BenchmarkDemo implemented - simple app for comparing serialization and parsing performance of popular Gson and Jackson libs. We were curios of performance of another popular library, used in some of our projects - of google-http-client-jackson2 serializer. We've implemented test like those done with other libs in BenchmarkDemo.
Here are results and code:
https://www.dropbox.com/s/qqfbm4rr5yg7pxi/Screenshot_2015-08-04-16-34-02.png?dl=0
https://www.dropbox.com/s/85del6wnyfxgpay/Screenshot_2015-08-04-16-34-56.png?dl=0
(If interested, it's Samsung Note 2 Android 4.3)
Surprising, this library is the slowest. Maybe you have some ideas why?
Please check if our benchmark is optimized enough.

The main reason why we prefer this library is that it can handle situation when json has null value vs json key is absent. It is done via Data.isNull(). And this functionality is important for us.
Are you going to add it to LoganSquare or we can do it ourselves in next pull request?