### PR TITLE
Issue #76: Compilation Issues if JSON Node Name has Space

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Like all libraries that generate dynamic code, Proguard might think some classes
 
 ```
 -keep class com.bluelinelabs.logansquare.** { *; }
+-keep @com.bluelinelabs.logansquare.annotation.JsonObject class *
 -keep class **$$JsonObjectMapper { *; }
 ```
 

--- a/processor/src/main/java/com/bluelinelabs/logansquare/processor/ObjectMapperInjector.java
+++ b/processor/src/main/java/com/bluelinelabs/logansquare/processor/ObjectMapperInjector.java
@@ -18,6 +18,8 @@ import java.io.IOException;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.List;
+import java.util.ArrayList;
 
 public class ObjectMapperInjector {
 
@@ -173,6 +175,7 @@ public class ObjectMapperInjector {
                 .addStatement("$L.writeStartObject()", JSON_GENERATOR_VARIABLE_NAME)
                 .endControlFlow();
 
+        List<String> processedFields = new ArrayList<>(mJsonObjectHolder.fieldMap.size());
         for (Map.Entry<String, JsonFieldHolder> entry : mJsonObjectHolder.fieldMap.entrySet()) {
             JsonFieldHolder fieldHolder = entry.getValue();
 
@@ -184,7 +187,7 @@ public class ObjectMapperInjector {
                     getter = "object." + entry.getKey();
                 }
 
-                fieldHolder.type.serialize(builder, 1, fieldHolder.fieldName[0], getter, true, true, mJsonObjectHolder.serializeNullObjects, mJsonObjectHolder.serializeNullCollectionElements);
+                fieldHolder.type.serialize(builder, 1, fieldHolder.fieldName[0], processedFields, getter, true, true, mJsonObjectHolder.serializeNullObjects, mJsonObjectHolder.serializeNullCollectionElements);
             }
         }
 

--- a/processor/src/main/java/com/bluelinelabs/logansquare/processor/TextUtils.java
+++ b/processor/src/main/java/com/bluelinelabs/logansquare/processor/TextUtils.java
@@ -12,6 +12,7 @@ public class TextUtils {
     public static String toUniqueFieldNameVariable(String fieldName, List<String> processedFieldNames) {
         fieldName = fieldName.replaceAll(" ", "");
         int frequency = Collections.frequency(processedFieldNames, fieldName);
+        processedFieldNames.add(fieldName);
         return (frequency > 0) ? fieldName + frequency : fieldName;
     }
 

--- a/processor/src/main/java/com/bluelinelabs/logansquare/processor/TextUtils.java
+++ b/processor/src/main/java/com/bluelinelabs/logansquare/processor/TextUtils.java
@@ -1,9 +1,18 @@
 package com.bluelinelabs.logansquare.processor;
 
+import java.util.Collections;
+import java.util.List;
+
 public class TextUtils {
 
     public static boolean isEmpty(String string) {
         return string == null || string.length() == 0;
+    }
+
+    public static String toUniqueFieldNameVariable(String fieldName, List<String> processedFieldNames) {
+        fieldName = fieldName.replaceAll(" ", "");
+        int frequency = Collections.frequency(processedFieldNames, fieldName);
+        return (frequency > 0) ? fieldName + frequency : fieldName;
     }
 
     public static String toUpperCaseWithUnderscores(String className) {

--- a/processor/src/main/java/com/bluelinelabs/logansquare/processor/type/Type.java
+++ b/processor/src/main/java/com/bluelinelabs/logansquare/processor/type/Type.java
@@ -20,7 +20,7 @@ public abstract class Type {
     public abstract String getParameterizedTypeString();
     public abstract Object[] getParameterizedTypeStringArgs();
     public abstract void parse(MethodSpec.Builder builder, int depth, String setter, Object... setterFormatArgs);
-    public abstract void serialize(MethodSpec.Builder builder, int depth, String fieldName, String getter, boolean isObjectProperty, boolean checkIfNull, boolean writeIfNull, boolean writeCollectionElementIfNull);
+    public abstract void serialize(MethodSpec.Builder builder, int depth, String fieldName, List<String> processedFieldNames, String getter, boolean isObjectProperty, boolean checkIfNull, boolean writeIfNull, boolean writeCollectionElementIfNull);
 
     public static Type typeFor(TypeMirror typeMirror, TypeMirror typeConverterType, Elements elements, Types types) {
         TypeMirror genericClassTypeMirror = types.erasure(typeMirror);

--- a/processor/src/main/java/com/bluelinelabs/logansquare/processor/type/container/ArrayCollectionType.java
+++ b/processor/src/main/java/com/bluelinelabs/logansquare/processor/type/container/ArrayCollectionType.java
@@ -1,10 +1,8 @@
 package com.bluelinelabs.logansquare.processor.type.container;
 
 import com.bluelinelabs.logansquare.processor.TextUtils;
-import com.bluelinelabs.logansquare.processor.type.field.FieldType;
 import com.fasterxml.jackson.core.JsonToken;
 import com.squareup.javapoet.ArrayTypeName;
-import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.MethodSpec;
 import com.squareup.javapoet.MethodSpec.Builder;
 import com.squareup.javapoet.TypeName;
@@ -78,7 +76,6 @@ public class ArrayCollectionType extends ContainerType {
     @Override
     public void serialize(MethodSpec.Builder builder, int depth, String fieldName, List<String> processedFieldNames, String getter, boolean isObjectProperty, boolean checkIfNull, boolean writeIfNull, boolean writeCollectionElementIfNull) {
         final String cleanFieldName = TextUtils.toUniqueFieldNameVariable(fieldName, processedFieldNames);
-        processedFieldNames.add(fieldName);
         final String collectionVariableName = "lslocal" + cleanFieldName;
         final String elementVarName = "element" + depth;
 

--- a/processor/src/main/java/com/bluelinelabs/logansquare/processor/type/container/ArrayCollectionType.java
+++ b/processor/src/main/java/com/bluelinelabs/logansquare/processor/type/container/ArrayCollectionType.java
@@ -1,5 +1,6 @@
 package com.bluelinelabs.logansquare.processor.type.container;
 
+import com.bluelinelabs.logansquare.processor.TextUtils;
 import com.bluelinelabs.logansquare.processor.type.field.FieldType;
 import com.fasterxml.jackson.core.JsonToken;
 import com.squareup.javapoet.ArrayTypeName;
@@ -75,8 +76,10 @@ public class ArrayCollectionType extends ContainerType {
     }
 
     @Override
-    public void serialize(MethodSpec.Builder builder, int depth, String fieldName, String getter, boolean isObjectProperty, boolean checkIfNull, boolean writeIfNull, boolean writeCollectionElementIfNull) {
-        String collectionVariableName = "lslocal" + fieldName;
+    public void serialize(MethodSpec.Builder builder, int depth, String fieldName, List<String> processedFieldNames, String getter, boolean isObjectProperty, boolean checkIfNull, boolean writeIfNull, boolean writeCollectionElementIfNull) {
+        final String cleanFieldName = TextUtils.toUniqueFieldNameVariable(fieldName, processedFieldNames);
+        processedFieldNames.add(fieldName);
+        final String collectionVariableName = "lslocal" + cleanFieldName;
         final String elementVarName = "element" + depth;
 
         final String instanceCreator;
@@ -111,7 +114,7 @@ public class ArrayCollectionType extends ContainerType {
             builder.beginControlFlow("if ($L != null)", elementVarName);
         }
 
-        subType.serialize(builder, depth + 1, collectionVariableName + "Element", elementVarName, false, false, false, writeCollectionElementIfNull);
+        subType.serialize(builder, depth + 1, collectionVariableName + "Element", processedFieldNames, elementVarName, false, false, false, writeCollectionElementIfNull);
 
         if (!subType.getTypeName().isPrimitive()) {
             if (writeCollectionElementIfNull) {

--- a/processor/src/main/java/com/bluelinelabs/logansquare/processor/type/container/MapContainerType.java
+++ b/processor/src/main/java/com/bluelinelabs/logansquare/processor/type/container/MapContainerType.java
@@ -61,7 +61,6 @@ public abstract class MapContainerType extends ContainerType {
     @Override
     public void serialize(MethodSpec.Builder builder, int depth, String fieldName, List<String> processedFieldNames, String getter, boolean isObjectProperty, boolean checkIfNull, boolean writeIfNull, boolean writeCollectionElementIfNull) {
         final String cleanFieldName = TextUtils.toUniqueFieldNameVariable(fieldName, processedFieldNames);
-        processedFieldNames.add(cleanFieldName);
         final String mapVariableName = "lslocal" + cleanFieldName;
         final String entryVariableName = "entry" + depth;
 

--- a/processor/src/main/java/com/bluelinelabs/logansquare/processor/type/container/MapContainerType.java
+++ b/processor/src/main/java/com/bluelinelabs/logansquare/processor/type/container/MapContainerType.java
@@ -58,7 +58,8 @@ public abstract class MapContainerType extends ContainerType {
 
     @Override
     public void serialize(MethodSpec.Builder builder, int depth, String fieldName, String getter, boolean isObjectProperty, boolean checkIfNull, boolean writeIfNull, boolean writeCollectionElementIfNull) {
-        final String mapVariableName = "lslocal" + fieldName;
+        final String cleanFieldName = fieldName.replaceAll(" ", "");
+        final String mapVariableName = "lslocal" + cleanFieldName;
         final String entryVariableName = "entry" + depth;
 
         final String instanceCreator = String.format("final $T<$T, %s> $L = $L", subType.getParameterizedTypeString());

--- a/processor/src/main/java/com/bluelinelabs/logansquare/processor/type/container/MapContainerType.java
+++ b/processor/src/main/java/com/bluelinelabs/logansquare/processor/type/container/MapContainerType.java
@@ -1,10 +1,12 @@
 package com.bluelinelabs.logansquare.processor.type.container;
 
+import com.bluelinelabs.logansquare.processor.TextUtils;
 import com.fasterxml.jackson.core.JsonToken;
 import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.MethodSpec;
 import com.squareup.javapoet.MethodSpec.Builder;
 
+import java.util.List;
 import java.util.Map;
 
 import static com.bluelinelabs.logansquare.processor.ObjectMapperInjector.JSON_GENERATOR_VARIABLE_NAME;
@@ -57,8 +59,9 @@ public abstract class MapContainerType extends ContainerType {
     }
 
     @Override
-    public void serialize(MethodSpec.Builder builder, int depth, String fieldName, String getter, boolean isObjectProperty, boolean checkIfNull, boolean writeIfNull, boolean writeCollectionElementIfNull) {
-        final String cleanFieldName = fieldName.replaceAll(" ", "");
+    public void serialize(MethodSpec.Builder builder, int depth, String fieldName, List<String> processedFieldNames, String getter, boolean isObjectProperty, boolean checkIfNull, boolean writeIfNull, boolean writeCollectionElementIfNull) {
+        final String cleanFieldName = TextUtils.toUniqueFieldNameVariable(fieldName, processedFieldNames);
+        processedFieldNames.add(cleanFieldName);
         final String mapVariableName = "lslocal" + cleanFieldName;
         final String entryVariableName = "entry" + depth;
 
@@ -82,7 +85,7 @@ public abstract class MapContainerType extends ContainerType {
                 .addStatement("$L.writeFieldName($L.getKey().toString())", JSON_GENERATOR_VARIABLE_NAME, entryVariableName)
                 .beginControlFlow("if ($L.getValue() != null)", entryVariableName);
 
-        subType.serialize(builder, depth + 1, mapVariableName + "Element", entryVariableName + ".getValue()", false, false, true, writeCollectionElementIfNull);
+        subType.serialize(builder, depth + 1, mapVariableName + "Element", processedFieldNames, entryVariableName + ".getValue()", false, false, true, writeCollectionElementIfNull);
 
         if (writeCollectionElementIfNull) {
             builder

--- a/processor/src/main/java/com/bluelinelabs/logansquare/processor/type/container/SingleParameterCollectionType.java
+++ b/processor/src/main/java/com/bluelinelabs/logansquare/processor/type/container/SingleParameterCollectionType.java
@@ -1,8 +1,11 @@
 package com.bluelinelabs.logansquare.processor.type.container;
 
+import com.bluelinelabs.logansquare.processor.TextUtils;
 import com.fasterxml.jackson.core.JsonToken;
 import com.squareup.javapoet.MethodSpec;
 import com.squareup.javapoet.MethodSpec.Builder;
+
+import java.util.List;
 
 import static com.bluelinelabs.logansquare.processor.ObjectMapperInjector.JSON_GENERATOR_VARIABLE_NAME;
 import static com.bluelinelabs.logansquare.processor.ObjectMapperInjector.JSON_PARSER_VARIABLE_NAME;
@@ -38,8 +41,9 @@ public abstract class SingleParameterCollectionType extends ContainerType {
     }
 
     @Override
-    public void serialize(MethodSpec.Builder builder, int depth, String fieldName, String getter, boolean isObjectProperty, boolean checkIfNull, boolean writeIfNull, boolean writeCollectionElementIfNull) {
-        final String cleanFieldName = fieldName.replaceAll(" ", "");
+    public void serialize(MethodSpec.Builder builder, int depth, String fieldName, List<String> processedFieldNames, String getter, boolean isObjectProperty, boolean checkIfNull, boolean writeIfNull, boolean writeCollectionElementIfNull) {
+        final String cleanFieldName = TextUtils.toUniqueFieldNameVariable(fieldName, processedFieldNames);
+        processedFieldNames.add(cleanFieldName);
         final String collectionVariableName = "lslocal" + cleanFieldName;
         final String elementVarName = "element" + depth;
 
@@ -62,7 +66,7 @@ public abstract class SingleParameterCollectionType extends ContainerType {
                 .beginControlFlow(forLine, forLineArgs)
                 .beginControlFlow("if ($L != null)", elementVarName);
 
-        subType.serialize(builder, depth + 1, collectionVariableName + "Element", elementVarName, false, false, false, writeCollectionElementIfNull);
+        subType.serialize(builder, depth + 1, collectionVariableName + "Element", processedFieldNames, elementVarName, false, false, false, writeCollectionElementIfNull);
 
         if (writeCollectionElementIfNull) {
             builder

--- a/processor/src/main/java/com/bluelinelabs/logansquare/processor/type/container/SingleParameterCollectionType.java
+++ b/processor/src/main/java/com/bluelinelabs/logansquare/processor/type/container/SingleParameterCollectionType.java
@@ -43,7 +43,6 @@ public abstract class SingleParameterCollectionType extends ContainerType {
     @Override
     public void serialize(MethodSpec.Builder builder, int depth, String fieldName, List<String> processedFieldNames, String getter, boolean isObjectProperty, boolean checkIfNull, boolean writeIfNull, boolean writeCollectionElementIfNull) {
         final String cleanFieldName = TextUtils.toUniqueFieldNameVariable(fieldName, processedFieldNames);
-        processedFieldNames.add(cleanFieldName);
         final String collectionVariableName = "lslocal" + cleanFieldName;
         final String elementVarName = "element" + depth;
 

--- a/processor/src/main/java/com/bluelinelabs/logansquare/processor/type/container/SingleParameterCollectionType.java
+++ b/processor/src/main/java/com/bluelinelabs/logansquare/processor/type/container/SingleParameterCollectionType.java
@@ -39,7 +39,8 @@ public abstract class SingleParameterCollectionType extends ContainerType {
 
     @Override
     public void serialize(MethodSpec.Builder builder, int depth, String fieldName, String getter, boolean isObjectProperty, boolean checkIfNull, boolean writeIfNull, boolean writeCollectionElementIfNull) {
-        String collectionVariableName = "lslocal" + fieldName;
+        final String cleanFieldName = fieldName.replaceAll(" ", "");
+        final String collectionVariableName = "lslocal" + cleanFieldName;
         final String elementVarName = "element" + depth;
 
         final String instanceCreator = String.format("final $T<%s> $L = $L", subType.getParameterizedTypeString());

--- a/processor/src/main/java/com/bluelinelabs/logansquare/processor/type/field/BooleanFieldType.java
+++ b/processor/src/main/java/com/bluelinelabs/logansquare/processor/type/field/BooleanFieldType.java
@@ -4,6 +4,8 @@ import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.MethodSpec.Builder;
 import com.squareup.javapoet.TypeName;
 
+import java.util.List;
+
 import static com.bluelinelabs.logansquare.processor.ObjectMapperInjector.JSON_GENERATOR_VARIABLE_NAME;
 import static com.bluelinelabs.logansquare.processor.ObjectMapperInjector.JSON_PARSER_VARIABLE_NAME;
 
@@ -37,7 +39,7 @@ public class BooleanFieldType extends FieldType {
     }
 
     @Override
-    public void serialize(Builder builder, int depth, String fieldName, String getter, boolean isObjectProperty, boolean checkIfNull, boolean writeIfNull, boolean writeCollectionElementIfNull) {
+    public void serialize(Builder builder, int depth, String fieldName, List<String> processedFieldNames, String getter, boolean isObjectProperty, boolean checkIfNull, boolean writeIfNull, boolean writeCollectionElementIfNull) {
         if (!isPrimitive && checkIfNull) {
             builder.beginControlFlow("if ($L != null)", getter);
         }

--- a/processor/src/main/java/com/bluelinelabs/logansquare/processor/type/field/DynamicFieldType.java
+++ b/processor/src/main/java/com/bluelinelabs/logansquare/processor/type/field/DynamicFieldType.java
@@ -4,6 +4,8 @@ import com.bluelinelabs.logansquare.LoganSquare;
 import com.squareup.javapoet.MethodSpec.Builder;
 import com.squareup.javapoet.TypeName;
 
+import java.util.List;
+
 import static com.bluelinelabs.logansquare.processor.ObjectMapperInjector.JSON_GENERATOR_VARIABLE_NAME;
 import static com.bluelinelabs.logansquare.processor.ObjectMapperInjector.JSON_PARSER_VARIABLE_NAME;
 
@@ -32,7 +34,7 @@ public class DynamicFieldType extends FieldType {
     }
 
     @Override
-    public void serialize(Builder builder, int depth, String fieldName, String getter, boolean isObjectProperty, boolean checkIfNull, boolean writeIfNull, boolean writeCollectionElementIfNull) {
+    public void serialize(Builder builder, int depth, String fieldName, List<String> processedFieldNames, String getter, boolean isObjectProperty, boolean checkIfNull, boolean writeIfNull, boolean writeCollectionElementIfNull) {
         if (!mTypeName.isPrimitive() && checkIfNull) {
             builder.beginControlFlow("if ($L != null)", getter);
         }

--- a/processor/src/main/java/com/bluelinelabs/logansquare/processor/type/field/JsonFieldType.java
+++ b/processor/src/main/java/com/bluelinelabs/logansquare/processor/type/field/JsonFieldType.java
@@ -5,6 +5,8 @@ import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.MethodSpec.Builder;
 import com.squareup.javapoet.TypeName;
 
+import java.util.List;
+
 import static com.bluelinelabs.logansquare.processor.ObjectMapperInjector.JSON_GENERATOR_VARIABLE_NAME;
 import static com.bluelinelabs.logansquare.processor.ObjectMapperInjector.JSON_PARSER_VARIABLE_NAME;
 
@@ -35,7 +37,7 @@ public class JsonFieldType extends FieldType {
     }
 
     @Override
-    public void serialize(Builder builder, int depth, String fieldName, String getter, boolean isObjectProperty, boolean checkIfNull, boolean writeIfNull, boolean writeCollectionElementIfNull) {
+    public void serialize(Builder builder, int depth, String fieldName, List<String> processedFieldNames, String getter, boolean isObjectProperty, boolean checkIfNull, boolean writeIfNull, boolean writeCollectionElementIfNull) {
 
         if (checkIfNull) {
             builder.beginControlFlow("if ($L != null)", getter);

--- a/processor/src/main/java/com/bluelinelabs/logansquare/processor/type/field/NumberFieldType.java
+++ b/processor/src/main/java/com/bluelinelabs/logansquare/processor/type/field/NumberFieldType.java
@@ -2,6 +2,8 @@ package com.bluelinelabs.logansquare.processor.type.field;
 
 import com.squareup.javapoet.MethodSpec.Builder;
 
+import java.util.List;
+
 import static com.bluelinelabs.logansquare.processor.ObjectMapperInjector.JSON_GENERATOR_VARIABLE_NAME;
 
 public abstract class NumberFieldType extends FieldType {
@@ -13,7 +15,7 @@ public abstract class NumberFieldType extends FieldType {
     }
 
     @Override
-    public void serialize(Builder builder, int depth, String fieldName, String getter, boolean isObjectProperty, boolean checkIfNull, boolean writeIfNull, boolean writeCollectionElementIfNull) {
+    public void serialize(Builder builder, int depth, String fieldName, List<String> processedFieldNames, String getter, boolean isObjectProperty, boolean checkIfNull, boolean writeIfNull, boolean writeCollectionElementIfNull) {
         if (!isPrimitive && checkIfNull) {
             builder.beginControlFlow("if ($L != null)", getter);
         }

--- a/processor/src/main/java/com/bluelinelabs/logansquare/processor/type/field/StringFieldType.java
+++ b/processor/src/main/java/com/bluelinelabs/logansquare/processor/type/field/StringFieldType.java
@@ -4,6 +4,8 @@ import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.MethodSpec.Builder;
 import com.squareup.javapoet.TypeName;
 
+import java.util.List;
+
 import static com.bluelinelabs.logansquare.processor.ObjectMapperInjector.JSON_GENERATOR_VARIABLE_NAME;
 import static com.bluelinelabs.logansquare.processor.ObjectMapperInjector.JSON_PARSER_VARIABLE_NAME;
 
@@ -26,7 +28,7 @@ public class StringFieldType extends FieldType {
     }
 
     @Override
-    public void serialize(Builder builder, int depth, String fieldName, String getter, boolean isObjectProperty, boolean checkIfNull, boolean writeIfNull, boolean writeCollectionElementIfNull) {
+    public void serialize(Builder builder, int depth, String fieldName, List<String> processedFieldNames, String getter, boolean isObjectProperty, boolean checkIfNull, boolean writeIfNull, boolean writeCollectionElementIfNull) {
         if (checkIfNull) {
             builder.beginControlFlow("if ($L != null)", getter);
         }

--- a/processor/src/main/java/com/bluelinelabs/logansquare/processor/type/field/TypeConverterFieldType.java
+++ b/processor/src/main/java/com/bluelinelabs/logansquare/processor/type/field/TypeConverterFieldType.java
@@ -5,6 +5,8 @@ import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.MethodSpec.Builder;
 import com.squareup.javapoet.TypeName;
 
+import java.util.List;
+
 import static com.bluelinelabs.logansquare.processor.ObjectMapperInjector.JSON_GENERATOR_VARIABLE_NAME;
 import static com.bluelinelabs.logansquare.processor.ObjectMapperInjector.JSON_PARSER_VARIABLE_NAME;
 
@@ -39,7 +41,7 @@ public class TypeConverterFieldType extends FieldType {
     }
 
     @Override
-    public void serialize(Builder builder, int depth, String fieldName, String getter, boolean isObjectProperty, boolean checkIfNull, boolean writeIfNull, boolean writeCollectionElementIfNull) {
+    public void serialize(Builder builder, int depth, String fieldName, List<String> processedFieldNames, String getter, boolean isObjectProperty, boolean checkIfNull, boolean writeIfNull, boolean writeCollectionElementIfNull) {
         builder.addStatement("$L.serialize($L, $S, $L, $L)", TextUtils.toUpperCaseWithUnderscores(mTypeConverter.simpleName()), getter, fieldName, isObjectProperty, JSON_GENERATOR_VARIABLE_NAME);
     }
 }

--- a/processor/src/test/java/com/bluelinelabs/logansquare/processor/WhitespaceFieldNameModelTest.java
+++ b/processor/src/test/java/com/bluelinelabs/logansquare/processor/WhitespaceFieldNameModelTest.java
@@ -1,0 +1,20 @@
+package com.bluelinelabs.logansquare.processor;
+
+import com.google.testing.compile.JavaFileObjects;
+import org.junit.Test;
+
+import static com.google.common.truth.Truth.ASSERT;
+import static com.google.testing.compile.JavaSourceSubjectFactory.javaSource;
+
+public class WhitespaceFieldNameModelTest {
+
+    @Test
+    public void generatedSource() {
+        ASSERT.about(javaSource())
+                .that(JavaFileObjects.forResource("model/good/WhitespaceFieldNameModel.java"))
+                .processedWith(new JsonAnnotationProcessor())
+                .compilesWithoutError()
+                .and()
+                .generatesSources(JavaFileObjects.forResource("generated/WhitespaceFieldNameModel$$JsonObjectMapper.java"));
+    }
+}

--- a/processor/src/test/resources/generated/WhitespaceFieldNameModel$$JsonObjectMapper.java
+++ b/processor/src/test/resources/generated/WhitespaceFieldNameModel$$JsonObjectMapper.java
@@ -1,4 +1,4 @@
-package com.bluelinelabs.logansquare.processor;
+package com.bluelinelabs.logansquare.processor.model;
 
 import com.bluelinelabs.logansquare.JsonMapper;
 import com.fasterxml.jackson.core.JsonGenerator;
@@ -51,6 +51,18 @@ public final class WhitespaceFieldNameModel$$JsonObjectMapper extends JsonMapper
       } else{
         instance.addressLines = null;
       }
+    } else if ("AddressLines".equals(fieldName)){
+      if (jsonParser.getCurrentToken() == JsonToken.START_ARRAY) {
+        ArrayList<String> collection1 = new ArrayList<String>();
+        while (jsonParser.nextToken() != JsonToken.END_ARRAY) {
+          String value1;
+          value1 = jsonParser.getValueAsString(null);
+          collection1.add(value1);
+        }
+        instance.addressLinesDuplicate = collection1;
+      } else{
+        instance.addressLinesDuplicate = null;
+      }
     } else if ("All Contacts".equals(fieldName)){
       if (jsonParser.getCurrentToken() == JsonToken.START_OBJECT) {
         HashMap<String, String> map1 = new HashMap<String, String>();
@@ -69,6 +81,19 @@ public final class WhitespaceFieldNameModel$$JsonObjectMapper extends JsonMapper
       }
     } else if ("Full Name".equals(fieldName)){
       instance.fullName = jsonParser.getValueAsString(null);
+    } else if ("Pet Names".equals(fieldName)){
+      if (jsonParser.getCurrentToken() == JsonToken.START_ARRAY) {
+        List<String> collection1 = new ArrayList<String>();
+        while (jsonParser.nextToken() != JsonToken.END_ARRAY) {
+          String value1;
+          value1 = jsonParser.getValueAsString(null);
+          collection1.add(value1);
+        }
+        String[] array = collection1.toArray(new String[collection1.size()]);
+        instance.petNames = array;
+      } else{
+        instance.petNames = null;
+      }
     }
   }
 
@@ -92,6 +117,17 @@ public final class WhitespaceFieldNameModel$$JsonObjectMapper extends JsonMapper
       }
       jsonGenerator.writeEndArray();
     }
+    final List<String> lslocalAddressLines1 = object.addressLinesDuplicate;
+    if (lslocalAddressLines1 != null) {
+      jsonGenerator.writeFieldName("AddressLines");
+      jsonGenerator.writeStartArray();
+      for (String element1 : lslocalAddressLines1) {
+        if (element1 != null) {
+          jsonGenerator.writeString(element1);
+        }
+      }
+      jsonGenerator.writeEndArray();
+    }
     final Map<String, String> lslocalAllContacts = object.allContacts;
     if (lslocalAllContacts != null) {
       jsonGenerator.writeFieldName("All Contacts");
@@ -106,6 +142,17 @@ public final class WhitespaceFieldNameModel$$JsonObjectMapper extends JsonMapper
     }
     if (object.fullName != null) {
       jsonGenerator.writeStringField("Full Name", object.fullName);
+    }
+    final String[] lslocalPetNames = object.petNames;
+    if (lslocalPetNames != null) {
+      jsonGenerator.writeFieldName("Pet Names");
+      jsonGenerator.writeStartArray();
+      for (String element1 : lslocalPetNames) {
+        if (element1 != null) {
+          jsonGenerator.writeString(element1);
+        }
+      }
+      jsonGenerator.writeEndArray();
     }
     if (writeStartAndEnd) {
       jsonGenerator.writeEndObject();

--- a/processor/src/test/resources/generated/WhitespaceFieldNameModel$$JsonObjectMapper.java
+++ b/processor/src/test/resources/generated/WhitespaceFieldNameModel$$JsonObjectMapper.java
@@ -1,0 +1,114 @@
+package com.bluelinelabs.logansquare.processor;
+
+import com.bluelinelabs.logansquare.JsonMapper;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import java.io.IOException;
+import java.lang.Override;
+import java.lang.String;
+import java.lang.SuppressWarnings;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@SuppressWarnings("unsafe")
+public final class WhitespaceFieldNameModel$$JsonObjectMapper extends JsonMapper<WhitespaceFieldNameModel> {
+  @Override
+  public WhitespaceFieldNameModel parse(JsonParser jsonParser) throws IOException {
+    return _parse(jsonParser);
+  }
+
+  public static WhitespaceFieldNameModel _parse(JsonParser jsonParser) throws IOException {
+    WhitespaceFieldNameModel instance = new WhitespaceFieldNameModel();
+    if (jsonParser.getCurrentToken() == null) {
+      jsonParser.nextToken();
+    }
+    if (jsonParser.getCurrentToken() != JsonToken.START_OBJECT) {
+      jsonParser.skipChildren();
+      return null;
+    }
+    while (jsonParser.nextToken() != JsonToken.END_OBJECT) {
+      String fieldName = jsonParser.getCurrentName();
+      jsonParser.nextToken();
+      parseField(instance, fieldName, jsonParser);
+      jsonParser.skipChildren();
+    }
+    return instance;
+  }
+
+  public static void parseField(WhitespaceFieldNameModel instance, String fieldName, JsonParser jsonParser) throws IOException {
+    if ("Address Lines".equals(fieldName)) {
+      if (jsonParser.getCurrentToken() == JsonToken.START_ARRAY) {
+        ArrayList<String> collection1 = new ArrayList<String>();
+        while (jsonParser.nextToken() != JsonToken.END_ARRAY) {
+          String value1;
+          value1 = jsonParser.getValueAsString(null);
+          collection1.add(value1);
+        }
+        instance.addressLines = collection1;
+      } else{
+        instance.addressLines = null;
+      }
+    } else if ("All Contacts".equals(fieldName)){
+      if (jsonParser.getCurrentToken() == JsonToken.START_OBJECT) {
+        HashMap<String, String> map1 = new HashMap<String, String>();
+        while (jsonParser.nextToken() != JsonToken.END_OBJECT) {
+          String key1 = jsonParser.getText();
+          jsonParser.nextToken();
+          if (jsonParser.getCurrentToken() == JsonToken.VALUE_NULL) {
+            map1.put(key1, null);
+          } else{
+            map1.put(key1, jsonParser.getValueAsString(null));
+          }
+        }
+        instance.allContacts = map1;
+      } else{
+        instance.allContacts = null;
+      }
+    } else if ("Full Name".equals(fieldName)){
+      instance.fullName = jsonParser.getValueAsString(null);
+    }
+  }
+
+  @Override
+  public void serialize(WhitespaceFieldNameModel object, JsonGenerator jsonGenerator, boolean writeStartAndEnd) throws IOException {
+    _serialize(object, jsonGenerator, writeStartAndEnd);
+  }
+
+  public static void _serialize(WhitespaceFieldNameModel object, JsonGenerator jsonGenerator, boolean writeStartAndEnd) throws IOException {
+    if (writeStartAndEnd) {
+      jsonGenerator.writeStartObject();
+    }
+    final List<String> lslocalAddressLines = object.addressLines;
+    if (lslocalAddressLines != null) {
+      jsonGenerator.writeFieldName("Address Lines");
+      jsonGenerator.writeStartArray();
+      for (String element1 : lslocalAddressLines) {
+        if (element1 != null) {
+          jsonGenerator.writeString(element1);
+        }
+      }
+      jsonGenerator.writeEndArray();
+    }
+    final Map<String, String> lslocalAllContacts = object.allContacts;
+    if (lslocalAllContacts != null) {
+      jsonGenerator.writeFieldName("All Contacts");
+      jsonGenerator.writeStartObject();
+      for (Map.Entry<String, String> entry1 : lslocalAllContacts.entrySet()) {
+        jsonGenerator.writeFieldName(entry1.getKey().toString());
+        if (entry1.getValue() != null) {
+          jsonGenerator.writeString(entry1.getValue());
+        }
+      }
+      jsonGenerator.writeEndObject();
+    }
+    if (object.fullName != null) {
+      jsonGenerator.writeStringField("Full Name", object.fullName);
+    }
+    if (writeStartAndEnd) {
+      jsonGenerator.writeEndObject();
+    }
+  }
+}

--- a/processor/src/test/resources/model/good/WhitespaceFieldNameModel.java
+++ b/processor/src/test/resources/model/good/WhitespaceFieldNameModel.java
@@ -1,0 +1,20 @@
+package com.bluelinelabs.logansquare.processor;
+
+import com.bluelinelabs.logansquare.annotation.JsonField;
+import com.bluelinelabs.logansquare.annotation.JsonObject;
+
+import java.util.List;
+import java.util.Map;
+
+@JsonObject
+public class WhitespaceFieldNameModel {
+
+    @JsonField(name = "Full Name")
+    public String fullName;
+
+    @JsonField(name = "Address Lines")
+    public List<String> addressLines;
+
+    @JsonField(name = "All Contacts")
+    public Map<String, String> allContacts;
+}

--- a/processor/src/test/resources/model/good/WhitespaceFieldNameModel.java
+++ b/processor/src/test/resources/model/good/WhitespaceFieldNameModel.java
@@ -1,4 +1,4 @@
-package com.bluelinelabs.logansquare.processor;
+package com.bluelinelabs.logansquare.processor.model;
 
 import com.bluelinelabs.logansquare.annotation.JsonField;
 import com.bluelinelabs.logansquare.annotation.JsonObject;
@@ -14,6 +14,12 @@ public class WhitespaceFieldNameModel {
 
     @JsonField(name = "Address Lines")
     public List<String> addressLines;
+
+    @JsonField(name = "Pet Names")
+    public String[] petNames;
+
+    @JsonField(name = "AddressLines")
+    public List<String> addressLinesDuplicate;
 
     @JsonField(name = "All Contacts")
     public Map<String, String> allContacts;


### PR DESCRIPTION
Both the MapContainer and SingleParameterCollection implementations of the Type interface did not perform whitespace trimming for field names upon serialization, which caused field declarations like the following to fail because of a syntax error:

```java
@JsonObject
public class WhitespaceFieldNameModel {

    @JsonField(name = "Full Name")
    public String fullName;

    @JsonField(name = "Address Lines")
    public List<String> addressLines;

    @JsonField(name = "All Contacts")
    public Map<String, String> allContacts;
}
```

Added field name cleaning and a new Test case for this. This fixes #76.