### PR TITLE
Made it possible to use LoganSquare with multiple modules

### DIFF
--- a/processor/src/main/java/com/bluelinelabs/logansquare/processor/JsonFieldHolder.java
+++ b/processor/src/main/java/com/bluelinelabs/logansquare/processor/JsonFieldHolder.java
@@ -7,6 +7,7 @@ import com.bluelinelabs.logansquare.processor.type.field.ParameterizedTypeField;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.TypeElement;
@@ -25,7 +26,7 @@ public class JsonFieldHolder {
     public boolean shouldSerialize;
     public Type type;
 
-    public String fill(Element element, Elements elements, Types types, String[] fieldNames, TypeMirror typeConverterType, JsonObjectHolder objectHolder, boolean shouldParse, boolean shouldSerialize) {
+    public String fill(Element element, ProcessingEnvironment env, Elements elements, Types types, String[] fieldNames, TypeMirror typeConverterType, JsonObjectHolder objectHolder, boolean shouldParse, boolean shouldSerialize) {
         if (fieldNames == null || fieldNames.length == 0) {
             String defaultFieldName = element.getSimpleName().toString();
 
@@ -45,7 +46,7 @@ public class JsonFieldHolder {
         setterMethod = getSetter(element, elements);
         getterMethod = getGetter(element, elements);
 
-        type = Type.typeFor(element.asType(), typeConverterType, elements, types);
+        type = Type.typeFor(element.asType(), typeConverterType, env, elements, types);
 
         return ensureValidType(type, element);
     }

--- a/processor/src/main/java/com/bluelinelabs/logansquare/processor/JsonMapperLoaderInjector.java
+++ b/processor/src/main/java/com/bluelinelabs/logansquare/processor/JsonMapperLoaderInjector.java
@@ -33,6 +33,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.Modifier;
 
 public class JsonMapperLoaderInjector {
@@ -41,9 +42,11 @@ public class JsonMapperLoaderInjector {
 
     private final Collection<JsonObjectHolder> mJsonObjectHolders;
     private final Map<Class, Class> mBuiltInMapperMap;
+    private final ProcessingEnvironment mProcessingEnv;
 
-    public JsonMapperLoaderInjector(Collection<JsonObjectHolder> jsonObjectHolders) {
+    public JsonMapperLoaderInjector(Collection<JsonObjectHolder> jsonObjectHolders, ProcessingEnvironment processingEnv) {
         mJsonObjectHolders = jsonObjectHolders;
+        mProcessingEnv = processingEnv;
 
         mBuiltInMapperMap = new HashMap<>();
         mBuiltInMapperMap.put(String.class, StringMapper.class);
@@ -68,7 +71,7 @@ public class JsonMapperLoaderInjector {
     }
 
     private TypeSpec getTypeSpec() {
-        TypeSpec.Builder builder = TypeSpec.classBuilder(Constants.LOADER_CLASS_NAME).addModifiers(Modifier.PUBLIC, Modifier.FINAL);
+        TypeSpec.Builder builder = TypeSpec.classBuilder(JsonAnnotationProcessor.getLoaderClassName(mProcessingEnv)).addModifiers(Modifier.PUBLIC, Modifier.FINAL);
         builder.addSuperinterface(ClassName.get(JsonMapperLoader.class));
 
         builder.addField(FieldSpec.builder(ParameterizedTypeName.get(ConcurrentHashMap.class, ParameterizedType.class, JsonMapper.class), PARAMETERIZED_MAPPERS_VARIABLE_NAME)
@@ -155,7 +158,7 @@ public class JsonMapperLoaderInjector {
 
                 typeSpecBuilder.addField(FieldSpec.builder(mapperTypeName, variableName)
                         .addModifiers(Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL)
-                        .initializer("new $T()", mapperTypeName)
+                        .initializer("$T.INSTANCE", mapperTypeName)
                         .build()
                 );
             }

--- a/processor/src/main/java/com/bluelinelabs/logansquare/processor/processor/JsonFieldProcessor.java
+++ b/processor/src/main/java/com/bluelinelabs/logansquare/processor/processor/JsonFieldProcessor.java
@@ -44,7 +44,7 @@ public class JsonFieldProcessor extends Processor {
     public void findAndParseObjects(RoundEnvironment env, Map<String, JsonObjectHolder> jsonObjectMap, Elements elements, Types types) {
         for (Element element : env.getElementsAnnotatedWith(JsonField.class)) {
             try {
-                processJsonFieldAnnotation(element, jsonObjectMap, elements, types);
+                processJsonFieldAnnotation(element, jsonObjectMap, mProcessingEnv, elements, types);
             } catch (Exception e) {
                 StringWriter stackTrace = new StringWriter();
                 e.printStackTrace(new PrintWriter(stackTrace));
@@ -54,7 +54,7 @@ public class JsonFieldProcessor extends Processor {
         }
     }
 
-    private void processJsonFieldAnnotation(Element element, Map<String, JsonObjectHolder> jsonObjectMap, Elements elements, Types types) {
+    private void processJsonFieldAnnotation(Element element, Map<String, JsonObjectHolder> jsonObjectMap, ProcessingEnvironment env, Elements elements, Types types) {
         if (!isJsonFieldFieldAnnotationValid(element, elements)) {
             return;
         }
@@ -84,7 +84,7 @@ public class JsonFieldProcessor extends Processor {
         boolean shouldParse = ignoreAnnotation == null || ignoreAnnotation.ignorePolicy() == IgnorePolicy.SERIALIZE_ONLY;
         boolean shouldSerialize = ignoreAnnotation == null || ignoreAnnotation.ignorePolicy() == IgnorePolicy.PARSE_ONLY;
 
-        String error = fieldHolder.fill(element, elements, types, fieldName, typeConverterType, objectHolder, shouldParse, shouldSerialize);
+        String error = fieldHolder.fill(element, env, elements, types, fieldName, typeConverterType, objectHolder, shouldParse, shouldSerialize);
         if (!TextUtils.isEmpty(error)) {
             error(element, error);
         }

--- a/processor/src/main/java/com/bluelinelabs/logansquare/processor/processor/JsonObjectProcessor.java
+++ b/processor/src/main/java/com/bluelinelabs/logansquare/processor/processor/JsonObjectProcessor.java
@@ -180,7 +180,7 @@ public class JsonObjectProcessor extends Processor {
                 objectHolder.fieldMap.put(element.getSimpleName().toString(), fieldHolder);
             }
 
-            String error = fieldHolder.fill(element, elements, types, null, null, objectHolder, shouldParse, shouldSerialize);
+            String error = fieldHolder.fill(element, mProcessingEnv, elements, types, null, null, objectHolder, shouldParse, shouldSerialize);
             if (!TextUtils.isEmpty(error)) {
                 error(element, error);
             }

--- a/processor/src/main/java/com/bluelinelabs/logansquare/processor/type/Type.java
+++ b/processor/src/main/java/com/bluelinelabs/logansquare/processor/type/Type.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.type.ArrayType;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.Elements;
@@ -30,16 +31,16 @@ public abstract class Type {
         parameterTypes = new ArrayList<>();
     }
 
-    public static Type typeFor(TypeMirror typeMirror, TypeMirror typeConverterType, Elements elements, Types types) {
+    public static Type typeFor(TypeMirror typeMirror, TypeMirror typeConverterType, ProcessingEnvironment env, Elements elements, Types types) {
         TypeMirror genericClassTypeMirror = types.erasure(typeMirror);
         boolean hasTypeConverter = typeConverterType != null && !typeConverterType.toString().equals("void");
 
         Type type;
         if (!hasTypeConverter && typeMirror instanceof ArrayType) {
             TypeMirror arrayTypeMirror = ((ArrayType)typeMirror).getComponentType();
-            type = new ArrayCollectionType(Type.typeFor(arrayTypeMirror, null, elements, types));
+            type = new ArrayCollectionType(Type.typeFor(arrayTypeMirror, null, env, elements, types));
         } else if (!hasTypeConverter && !genericClassTypeMirror.toString().equals(typeMirror.toString())) {
-            type = CollectionType.collectionTypeFor(typeMirror, genericClassTypeMirror, elements, types);
+            type = CollectionType.collectionTypeFor(typeMirror, genericClassTypeMirror, env, elements, types);
 
             if (type == null) {
                 if (typeMirror.toString().contains("?")) {
@@ -50,7 +51,7 @@ public abstract class Type {
                 } catch (Exception ignored) { }
             }
         } else {
-            type = FieldType.fieldTypeFor(typeMirror, typeConverterType, elements, types);
+            type = FieldType.fieldTypeFor(typeMirror, typeConverterType, env, elements, types);
         }
 
         return type;
@@ -69,13 +70,13 @@ public abstract class Type {
         return argList.toArray(new Object[argList.size()]);
     }
 
-    public void addParameterTypes(List<TypeMirror> parameterTypes, Elements elements, Types types) {
+    public void addParameterTypes(List<TypeMirror> parameterTypes, ProcessingEnvironment env, Elements elements, Types types) {
         for (TypeMirror typeMirror : parameterTypes) {
-            addParameterType(typeMirror, elements, types);
+            addParameterType(typeMirror, env, elements, types);
         }
     }
 
-    public void addParameterType(TypeMirror parameterType, Elements elements, Types types) {
-        parameterTypes.add(Type.typeFor(parameterType, null, elements, types));
+    public void addParameterType(TypeMirror parameterType, ProcessingEnvironment env, Elements elements, Types types) {
+        parameterTypes.add(Type.typeFor(parameterType, null, env, elements, types));
     }
 }

--- a/processor/src/main/java/com/bluelinelabs/logansquare/processor/type/collection/CollectionType.java
+++ b/processor/src/main/java/com/bluelinelabs/logansquare/processor/type/collection/CollectionType.java
@@ -4,6 +4,7 @@ import com.bluelinelabs.logansquare.processor.TypeUtils;
 import com.bluelinelabs.logansquare.processor.type.Type;
 import com.squareup.javapoet.ClassName;
 
+import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.Elements;
 import javax.lang.model.util.Types;
@@ -12,7 +13,7 @@ public abstract class CollectionType extends Type {
 
     private String mJsonMapperVariableName;
 
-    public static CollectionType collectionTypeFor(TypeMirror typeMirror, TypeMirror genericClassTypeMirror, Elements elements, Types types) {
+    public static CollectionType collectionTypeFor(TypeMirror typeMirror, TypeMirror genericClassTypeMirror, ProcessingEnvironment env, Elements elements, Types types) {
         CollectionType collectionType = null;
         switch (genericClassTypeMirror.toString()) {
             case "java.util.List":
@@ -44,7 +45,7 @@ public abstract class CollectionType extends Type {
         }
 
         if (collectionType != null) {
-            collectionType.addParameterTypes(TypeUtils.getParameterizedTypes(typeMirror), elements, types);
+            collectionType.addParameterTypes(TypeUtils.getParameterizedTypes(typeMirror), env, elements, types);
         }
 
         return collectionType;

--- a/processor/src/main/java/com/bluelinelabs/logansquare/processor/type/field/FieldType.java
+++ b/processor/src/main/java/com/bluelinelabs/logansquare/processor/type/field/FieldType.java
@@ -7,6 +7,7 @@ import com.squareup.javapoet.TypeName;
 
 import java.lang.annotation.Annotation;
 
+import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
@@ -27,7 +28,7 @@ public abstract class FieldType extends Type {
         return new Object[] { getNonPrimitiveTypeName() };
     }
 
-    public static FieldType fieldTypeFor(TypeMirror typeMirror, TypeMirror typeConverterType, Elements elements, Types types) {
+    public static FieldType fieldTypeFor(TypeMirror typeMirror, TypeMirror typeConverterType, ProcessingEnvironment env, Elements elements, Types types) {
         if (typeMirror != null) {
             if (typeConverterType != null && !"void".equals(typeConverterType.toString())) {
                 return new TypeConverterFieldType(TypeName.get(typeMirror), ClassName.bestGuess(typeConverterType.toString()));
@@ -58,11 +59,11 @@ public abstract class FieldType extends Type {
             } else if (String.class.getCanonicalName().equals(typeMirror.toString())) {
                 return new StringFieldType();
             } else if (Object.class.getCanonicalName().equals(typeMirror.toString())) {
-                return new UnknownFieldType();
+                return new UnknownFieldType(env);
             } else if (typeMirror instanceof DeclaredType) {
                 Annotation annotation = ((DeclaredType) typeMirror).asElement().getAnnotation(JsonObject.class);
                 if (annotation != null) {
-                    return new JsonFieldType(ClassName.bestGuess(typeMirror.toString()));
+                    return new JsonFieldType(env, ClassName.bestGuess(typeMirror.toString()));
                 }
             }
 

--- a/processor/src/main/java/com/bluelinelabs/logansquare/processor/type/field/UnknownFieldType.java
+++ b/processor/src/main/java/com/bluelinelabs/logansquare/processor/type/field/UnknownFieldType.java
@@ -2,11 +2,13 @@ package com.bluelinelabs.logansquare.processor.type.field;
 
 import com.bluelinelabs.logansquare.Constants;
 import com.bluelinelabs.logansquare.internal.objectmappers.ObjectMapper;
+import com.bluelinelabs.logansquare.processor.JsonAnnotationProcessor;
 import com.bluelinelabs.logansquare.processor.JsonMapperLoaderInjector;
 import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.MethodSpec.Builder;
 import com.squareup.javapoet.TypeName;
 
+import javax.annotation.processing.ProcessingEnvironment;
 import java.util.List;
 
 import static com.bluelinelabs.logansquare.processor.ObjectMapperInjector.JSON_GENERATOR_VARIABLE_NAME;
@@ -14,7 +16,11 @@ import static com.bluelinelabs.logansquare.processor.ObjectMapperInjector.JSON_P
 
 public class UnknownFieldType extends FieldType {
 
-    private final ClassName mLoaderClassName = ClassName.bestGuess(Constants.LOADER_PACKAGE_NAME + "." + Constants.LOADER_CLASS_NAME);
+    private final ClassName mLoaderClassName;
+
+    public UnknownFieldType(ProcessingEnvironment env) {
+        mLoaderClassName = ClassName.bestGuess(Constants.LOADER_PACKAGE_NAME + "." + JsonAnnotationProcessor.getLoaderClassName(env));
+    }
 
     @Override
     public TypeName getTypeName() {


### PR DESCRIPTION
This version added an option `jsonMapperLoaderSuffix` to LoganSquare, which allows user to specify suffix to JsonMapperLoader class implementation, user can now name JsonMapperLoader differently, in order to avoid clash on complilation. The behavior will be exactly the same as previous when no suffix specified.

To load multiple JsonMapperLoader, user needs to register their generated implementations in `META-INF/services/com.bluelinelabs.logansquare.internal.JsonMapperLoader`.

This is kind of complicated indeed, but it's so far the only compatible way for both Android and Java Standard to use LoganSquare in multiple modules at this time.

 I wish you could consider merge this. The code runs well on my projects (though I'm not sure whether my changes are compatible with generics), and I guess this could fix #104.