### PR TITLE
Fix for the eclipse compiler.

### DIFF
--- a/processor/src/main/java/com/bluelinelabs/logansquare/processor/type/collection/CollectionType.java
+++ b/processor/src/main/java/com/bluelinelabs/logansquare/processor/type/collection/CollectionType.java
@@ -12,32 +12,35 @@ public abstract class CollectionType extends Type {
 
     public static CollectionType collectionTypeFor(TypeMirror typeMirror, TypeMirror genericClassTypeMirror, Elements elements, Types types) {
         CollectionType collectionType = null;
-        switch (genericClassTypeMirror.toString()) {
+        
+        String typeMirrorInfo = genericClassTypeMirror.toString().replaceAll("<.*>", "");
+        
+        switch (typeMirrorInfo) {
             case "java.util.List":
             case "java.util.ArrayList":
-                collectionType = new ArrayListCollectionType(ClassName.bestGuess(genericClassTypeMirror.toString()));
+                collectionType = new ArrayListCollectionType(ClassName.bestGuess(typeMirrorInfo));
                 break;
             case "java.util.LinkedList":
-                collectionType = new LinkedListCollectionType(ClassName.bestGuess(genericClassTypeMirror.toString()));
+                collectionType = new LinkedListCollectionType(ClassName.bestGuess(typeMirrorInfo));
                 break;
             case "java.util.Map":
             case "java.util.HashMap":
-                collectionType = new HashMapCollectionType(ClassName.bestGuess(genericClassTypeMirror.toString()));
+                collectionType = new HashMapCollectionType(ClassName.bestGuess(typeMirrorInfo));
                 break;
             case "java.util.TreeMap":
-                collectionType = new TreeMapCollectionType(ClassName.bestGuess(genericClassTypeMirror.toString()));
+                collectionType = new TreeMapCollectionType(ClassName.bestGuess(typeMirrorInfo));
                 break;
             case "java.util.LinkedHashMap":
-                collectionType = new LinkedHashMapCollectionType(ClassName.bestGuess(genericClassTypeMirror.toString()));
+                collectionType = new LinkedHashMapCollectionType(ClassName.bestGuess(typeMirrorInfo));
                 break;
             case "java.util.Set":
             case "java.util.HashSet":
-                collectionType = new SetCollectionType(ClassName.bestGuess(genericClassTypeMirror.toString()));
+                collectionType = new SetCollectionType(ClassName.bestGuess(typeMirrorInfo));
                 break;
             case "java.util.Queue":
             case "java.util.Deque":
             case "java.util.ArrayDeque":
-                collectionType = new QueueCollectionType(ClassName.bestGuess(genericClassTypeMirror.toString()));
+                collectionType = new QueueCollectionType(ClassName.bestGuess(typeMirrorInfo));
                 break;
         }
 


### PR DESCRIPTION
_Eclipse compiler_
TypeMirror.toString() returns ```"java.util.List<E>"```

_Oracle compiler_
TypeMirror.toString() returns ```"java.util.List"```


I guess the better solution would be to use the Types.isSameType method. 
```
types.isSameType(typeMirror,    
        types.erasure(elements.getTypeElement(List.class.getCanonicalName()).asType()))
```    

But the method ClassName.bestGuess throws an exception with the argument ```"java.util.List<E>"```, so we need to remove ```<*>``` anyway.