### PR TITLE
DynamicFieldType: restore TypeConverter lookup

### DIFF
--- a/processor/src/main/java/com/bluelinelabs/logansquare/processor/type/field/DynamicFieldType.java
+++ b/processor/src/main/java/com/bluelinelabs/logansquare/processor/type/field/DynamicFieldType.java
@@ -1,6 +1,6 @@
 package com.bluelinelabs.logansquare.processor.type.field;
 
-import com.bluelinelabs.logansquare.processor.ObjectMapperInjector;
+import com.bluelinelabs.logansquare.LoganSquare;
 import com.squareup.javapoet.MethodSpec.Builder;
 import com.squareup.javapoet.TypeName;
 
@@ -30,8 +30,8 @@ public class DynamicFieldType extends FieldType {
 
     @Override
     public void parse(Builder builder, int depth, String setter, Object... setterFormatArgs) {
-        setter = replaceLastLiteral(setter, ObjectMapperInjector.getTypeConverterGetter(mTypeName) + "().parse($L)");
-        builder.addStatement(setter, expandStringArgs(setterFormatArgs, JSON_PARSER_VARIABLE_NAME));
+        setter = replaceLastLiteral(setter, "$T.typeConverterFor($T.class).parse($L)");
+        builder.addStatement(setter, expandStringArgs(setterFormatArgs, LoganSquare.class, mTypeName, JSON_PARSER_VARIABLE_NAME));
     }
 
     @Override
@@ -40,7 +40,8 @@ public class DynamicFieldType extends FieldType {
             builder.beginControlFlow("if ($L != null)", getter);
         }
 
-        builder.addStatement(ObjectMapperInjector.getTypeConverterGetter(mTypeName) + "().serialize($L, $S, $L, $L)", getter, isObjectProperty ? fieldName : null, isObjectProperty, JSON_GENERATOR_VARIABLE_NAME);
+        builder.addStatement("$T.typeConverterFor($T.class).serialize($L, $S, $L, $L)", LoganSquare.class, mTypeName, getter, isObjectProperty
+                ? fieldName : null, isObjectProperty, JSON_GENERATOR_VARIABLE_NAME);
 
         if (!mTypeName.isPrimitive() && checkIfNull) {
             if (writeIfNull) {


### PR DESCRIPTION
This was changed between LoganSquare 1.3.3 and 1.3.4.

Reverting this change fixes the compile-time error.

fixes GH-118
