### PR TITLE
Add generic enum mapper

### DIFF
--- a/core/src/main/java/com/bluelinelabs/logansquare/LoganSquare.java
+++ b/core/src/main/java/com/bluelinelabs/logansquare/LoganSquare.java
@@ -1,14 +1,6 @@
 package com.bluelinelabs.logansquare;
 
-import com.bluelinelabs.logansquare.internal.objectmappers.BooleanMapper;
-import com.bluelinelabs.logansquare.internal.objectmappers.DoubleMapper;
-import com.bluelinelabs.logansquare.internal.objectmappers.FloatMapper;
-import com.bluelinelabs.logansquare.internal.objectmappers.IntegerMapper;
-import com.bluelinelabs.logansquare.internal.objectmappers.ListMapper;
-import com.bluelinelabs.logansquare.internal.objectmappers.LongMapper;
-import com.bluelinelabs.logansquare.internal.objectmappers.MapMapper;
-import com.bluelinelabs.logansquare.internal.objectmappers.ObjectMapper;
-import com.bluelinelabs.logansquare.internal.objectmappers.StringMapper;
+import com.bluelinelabs.logansquare.internal.objectmappers.*;
 import com.bluelinelabs.logansquare.typeconverters.DefaultCalendarConverter;
 import com.bluelinelabs.logansquare.typeconverters.DefaultDateConverter;
 import com.bluelinelabs.logansquare.typeconverters.TypeConverter;
@@ -231,9 +223,14 @@ public class LoganSquare {
         if (mapper == null) {
             // The only way the mapper wouldn't already be loaded into OBJECT_MAPPERS is if it was compiled separately, but let's handle it anyway
             try {
-                Class<?> mapperClass = Class.forName(cls.getName() + Constants.MAPPER_CLASS_SUFFIX);
-                mapper = (JsonMapper<E>)mapperClass.newInstance();
-                OBJECT_MAPPERS.put(cls, mapper);
+                if (cls.isEnum()) {
+                    mapper = new EnumMapper(cls);
+                    OBJECT_MAPPERS.put(cls, mapper);
+                } else {
+                    Class<?> mapperClass = Class.forName(cls.getName() + Constants.MAPPER_CLASS_SUFFIX);
+                    mapper = (JsonMapper<E>) mapperClass.newInstance();
+                    OBJECT_MAPPERS.put(cls, mapper);
+                }
             } catch (Exception ignored) { }
         }
         return mapper;

--- a/core/src/main/java/com/bluelinelabs/logansquare/internal/objectmappers/EnumMapper.java
+++ b/core/src/main/java/com/bluelinelabs/logansquare/internal/objectmappers/EnumMapper.java
@@ -1,0 +1,28 @@
+package com.bluelinelabs.logansquare.internal.objectmappers;
+
+import com.bluelinelabs.logansquare.JsonMapper;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+
+import java.io.IOException;
+
+public class EnumMapper<E extends Enum<E>> extends JsonMapper<E> {
+    private final Class<E> enumCls;
+
+    public EnumMapper(Class<E> enumCls) {
+        this.enumCls = enumCls;
+    }
+
+    @Override
+    public E parse(JsonParser jsonParser) throws IOException {
+        return Enum.valueOf(enumCls, jsonParser.getText());
+    }
+
+    @Override
+    public void parseField(E instance, String fieldName, JsonParser jsonParser) throws IOException { }
+
+    @Override
+    public void serialize(E object, JsonGenerator generator, boolean writeStartAndEnd) throws IOException {
+        generator.writeString(object.name());
+    }
+}


### PR DESCRIPTION
This mapper simply uses the enum's name to serialize and deserialize any enum class without having to write a converter.

Tested with:

```
@JsonObject
public enum TestEnum {
    First, Second, Third
}
```

Serializing a `TestEnum` to JSON seems to work, but I can't be 100% sure as I can't figure out how to use this project's test framework. It did spit out proper-looking JSON when I tested it by just serializing a list of them, but I haven't been able to get the annotation processor working in my project, so I currently can't test with any custom classes.

Deserializing this object:

```
{
  "the_enum": "First",
  "another_enum": "Third"
}
```

with `LoganSquare.parseMap()` yields this: 
![image](https://cloud.githubusercontent.com/assets/1078569/13871108/2c8550bc-ecb8-11e5-81f5-1d103eb53797.png)

which looks good!

I mainly wanted to do this because after switching my project over from Gson, I missed the ease of how it handled Enums. This still needs work but I think it's a good starting point. Hopefully someone better versed in annotation processing can figure out a clean way to have field names overridden (like `@SerializedName` on an enum value in Gson).

Thanks for the great library!
