### PR TITLE
Fixed parent mapper name in generated mapper class of a member class

### DIFF
--- a/processor/src/main/java/com/bluelinelabs/logansquare/processor/processor/JsonObjectProcessor.java
+++ b/processor/src/main/java/com/bluelinelabs/logansquare/processor/processor/JsonObjectProcessor.java
@@ -98,8 +98,7 @@ public class JsonObjectProcessor extends Processor {
                 TypeElement superclassElement = (TypeElement)types.asElement(superclass);
 
                 if (superclassElement.getAnnotation(JsonObject.class) != null) {
-                    String superclassPackageName = elements.getPackageOf(superclassElement).getQualifiedName().toString();
-                    parentClassName = ClassName.get(superclassPackageName, TypeUtils.getSimpleClassName(superclassElement, superclassPackageName));
+                    parentClassName = ClassName.get(superclassElement);
                     break;
                 }
 


### PR DESCRIPTION
 For a example, if you have classes structured like this:

``` java

 public class Sample {

    @JsonObject
    public class A {

    }

    @JsonObject
    public class B extends A {

    }

 }

```

 You'll see errors during complication.

 That's because `Sample$B$$JsonObjectMapper#parentObjectMapper`
 referenced to wrong class name for A `Sample$A` instead of `Sample.A`.
