### PR TITLE
Add compile-time check for no-argument constructors

### DIFF
--- a/BenchmarkDemo/app/build.gradle
+++ b/BenchmarkDemo/app/build.gradle
@@ -39,9 +39,9 @@ dependencies {
     compile 'com.android.support:appcompat-v7:23.1.1'
 
     // LoganSquare annotation processor
-    apt 'com.bluelinelabs:logansquare-compiler:1.3.6'
+    apt 'com.bluelinelabs:logansquare-compiler:1.3.7'
     // LoganSquare runtime library
-    compile 'com.bluelinelabs:logansquare:1.3.6'
+    compile 'com.bluelinelabs:logansquare:1.3.7'
 
     // Jackson libraries for comparison
     compile 'com.fasterxml.jackson.core:jackson-databind:2.5.1'

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ buildscript {
 apply plugin: 'com.neenbedankt.android-apt'
 
 dependencies {
-    apt 'com.bluelinelabs:logansquare-compiler:1.3.6'
-    compile 'com.bluelinelabs:logansquare:1.3.6'
+    apt 'com.bluelinelabs:logansquare-compiler:1.3.7'
+    compile 'com.bluelinelabs:logansquare:1.3.7'
 }
 
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ allprojects {
     apply plugin: 'idea'
 
     group = 'com.bluelinelabs'
-    version = '1.3.6'
+    version = '1.3.7'
 }
 
 subprojects {

--- a/processor/src/main/java/com/bluelinelabs/logansquare/processor/processor/JsonObjectProcessor.java
+++ b/processor/src/main/java/com/bluelinelabs/logansquare/processor/processor/JsonObjectProcessor.java
@@ -23,11 +23,7 @@ import java.util.Set;
 
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.annotation.processing.RoundEnvironment;
-import javax.lang.model.element.Element;
-import javax.lang.model.element.ElementKind;
-import javax.lang.model.element.Modifier;
-import javax.lang.model.element.TypeElement;
-import javax.lang.model.element.TypeParameterElement;
+import javax.lang.model.element.*;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.Elements;
@@ -66,6 +62,22 @@ public class JsonObjectProcessor extends Processor {
 
         if (element.getModifiers().contains(PRIVATE)) {
             error(element, "%s: %s annotation can't be used on private classes.", typeElement.getQualifiedName(), JsonObject.class.getSimpleName());
+        }
+
+        boolean hasDefaultConstructor = false;
+        for (Element member : elements.getAllMembers(typeElement)) {
+            if (member.getKind() != ElementKind.CONSTRUCTOR) {
+                continue;
+            }
+
+            ExecutableElement methodElement = (ExecutableElement) member;
+            if (methodElement.getParameters().isEmpty() && !methodElement.getModifiers().contains(PRIVATE)) {
+                hasDefaultConstructor = true;
+            }
+        }
+
+        if (!hasDefaultConstructor) {
+            error(element, "%s: %s annotation requires a non-private empty constructor on this class.", typeElement.getQualifiedName(), JsonObject.class.getSimpleName());
         }
 
         JsonObjectHolder holder = jsonObjectMap.get(TypeUtils.getInjectedFQCN(typeElement, elements));

--- a/processor/src/main/java/com/bluelinelabs/logansquare/processor/type/Type.java
+++ b/processor/src/main/java/com/bluelinelabs/logansquare/processor/type/Type.java
@@ -78,6 +78,10 @@ public abstract class Type {
         }
     }
 
+    public void addParameterType(Type type) {
+        parameterTypes.add(type);
+    }
+
     public void addParameterType(TypeMirror parameterType, Elements elements, Types types) {
         parameterTypes.add(Type.typeFor(parameterType, null, elements, types));
     }

--- a/processor/src/main/java/com/bluelinelabs/logansquare/processor/type/collection/ArrayCollectionType.java
+++ b/processor/src/main/java/com/bluelinelabs/logansquare/processor/type/collection/ArrayCollectionType.java
@@ -21,6 +21,7 @@ public class ArrayCollectionType extends CollectionType {
 
     public ArrayCollectionType(Type arrayType) {
         this.arrayType = arrayType;
+        addParameterType(arrayType);
     }
 
     @Override

--- a/processor/src/main/java/com/bluelinelabs/logansquare/processor/type/field/DynamicFieldType.java
+++ b/processor/src/main/java/com/bluelinelabs/logansquare/processor/type/field/DynamicFieldType.java
@@ -1,6 +1,6 @@
 package com.bluelinelabs.logansquare.processor.type.field;
 
-import com.bluelinelabs.logansquare.LoganSquare;
+import com.bluelinelabs.logansquare.processor.ObjectMapperInjector;
 import com.squareup.javapoet.MethodSpec.Builder;
 import com.squareup.javapoet.TypeName;
 
@@ -30,8 +30,8 @@ public class DynamicFieldType extends FieldType {
 
     @Override
     public void parse(Builder builder, int depth, String setter, Object... setterFormatArgs) {
-        setter = replaceLastLiteral(setter, "$T.typeConverterFor($T.class).parse($L)");
-        builder.addStatement(setter, expandStringArgs(setterFormatArgs, LoganSquare.class, mTypeName, JSON_PARSER_VARIABLE_NAME));
+        setter = replaceLastLiteral(setter, ObjectMapperInjector.getTypeConverterGetter(mTypeName) + "().parse($L)");
+        builder.addStatement(setter, expandStringArgs(setterFormatArgs, JSON_PARSER_VARIABLE_NAME));
     }
 
     @Override
@@ -40,9 +40,7 @@ public class DynamicFieldType extends FieldType {
             builder.beginControlFlow("if ($L != null)", getter);
         }
 
-        builder.addStatement("$T.typeConverterFor($T.class).serialize($L, $S, $L, $L)", LoganSquare.class, mTypeName, getter, isObjectProperty
-                ? fieldName : null, isObjectProperty, JSON_GENERATOR_VARIABLE_NAME);
-
+        builder.addStatement(ObjectMapperInjector.getTypeConverterGetter(mTypeName) + "().serialize($L, $S, $L, $L)", getter, isObjectProperty ? fieldName : null, isObjectProperty, JSON_GENERATOR_VARIABLE_NAME);
         if (!mTypeName.isPrimitive() && checkIfNull) {
             if (writeIfNull) {
                 builder.nextControlFlow("else");

--- a/processor/src/test/java/com/bluelinelabs/logansquare/processor/NegativeTests.java
+++ b/processor/src/test/java/com/bluelinelabs/logansquare/processor/NegativeTests.java
@@ -61,4 +61,22 @@ public class NegativeTests {
                 .failsToCompile()
                 .withErrorContaining("There can only be one @OnJsonParseComplete method per class");
     }
+
+    @Test
+    public void noDefaultConstructor() {
+        ASSERT.about(javaSource())
+                .that(JavaFileObjects.forResource("model/bad/NoConstructorModel.java"))
+                .processedWith(new JsonAnnotationProcessor())
+                .failsToCompile()
+                .withErrorContaining("JsonObject annotation requires a non-private empty constructor on this class");
+    }
+
+    @Test
+    public void privateEmptyConstructor() {
+        ASSERT.about(javaSource())
+                .that(JavaFileObjects.forResource("model/bad/PrivateConstructorModel.java"))
+                .processedWith(new JsonAnnotationProcessor())
+                .failsToCompile()
+                .withErrorContaining("JsonObject annotation requires a non-private empty constructor on this class");
+    }
 }

--- a/processor/src/test/resources/model/bad/NoConstructorModel.java
+++ b/processor/src/test/resources/model/bad/NoConstructorModel.java
@@ -1,0 +1,15 @@
+package com.bluelinelabs.logansquare.processor.bad;
+
+import com.bluelinelabs.logansquare.annotation.JsonField;
+import com.bluelinelabs.logansquare.annotation.JsonObject;
+
+@JsonObject
+public class NoConstructorModel {
+
+    @JsonField(name = "value")
+    String value;
+
+    public NoConstructorModel(String value) {
+        this.value = value;
+    }
+}

--- a/processor/src/test/resources/model/bad/PrivateConstructorModel.java
+++ b/processor/src/test/resources/model/bad/PrivateConstructorModel.java
@@ -1,0 +1,14 @@
+package com.bluelinelabs.logansquare.processor.bad;
+
+import com.bluelinelabs.logansquare.annotation.JsonField;
+import com.bluelinelabs.logansquare.annotation.JsonObject;
+
+@JsonObject
+public class PrivateConstructorModel {
+
+    @JsonField(name = "value")
+    String value;
+
+    private PrivateConstructorModel() {
+    }
+}


### PR DESCRIPTION
Based on issue #170, this PR adds an additional check to the annotation processor, so that it raises a descriptive error message on annotated `@JsonObject` class without a no-argument constructor with sufficient visibility:

```
"JsonObject annotation requires a non-private empty constructor on this class."
```
