### PR TITLE
Fixed parentObjectMapper type name

### DIFF
--- a/processor/src/main/java/com/bluelinelabs/logansquare/processor/processor/JsonObjectProcessor.java
+++ b/processor/src/main/java/com/bluelinelabs/logansquare/processor/processor/JsonObjectProcessor.java
@@ -98,8 +98,7 @@ public class JsonObjectProcessor extends Processor {
                 TypeElement superclassElement = (TypeElement)types.asElement(superclass);
 
                 if (superclassElement.getAnnotation(JsonObject.class) != null) {
-                    String superclassPackageName = elements.getPackageOf(superclassElement).getQualifiedName().toString();
-                    parentClassName = ClassName.get(superclassPackageName, TypeUtils.getSimpleClassName(superclassElement, superclassPackageName));
+                    parentClassName = ClassName.get(superclassElement);
                     break;
                 }
 


### PR DESCRIPTION
parentObjectMapper in generated class will have problem

```
class ModelA {

    class ModelB {
    }

    class ModelC extends ModelB {
    }

}
```

This commit fixed problem above.
