### PR TITLE
Fix markdown headline/code formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Android Arsenal](https://img.shields.io/badge/Android%20Arsenal-LoganSquare-brightgreen.svg?style=flat)](https://android-arsenal.com/details/1/1550) [![Android Weekly](https://img.shields.io/badge/Android%20Weekly-141-blue.svg?style=flat)](http://androidweekly.net/issues/issue-141) [![Travis Build](https://travis-ci.org/bluelinelabs/LoganSquare.svg)](https://travis-ci.org/bluelinelabs/LoganSquare)
 
-#LoganSquare
+# LoganSquare
 
 The fastest JSON parsing and serializing library available for Android. Based on Jackson's streaming API, LoganSquare is able to consistently outperform GSON and Jackson's Databind library by 400% or more<sup>[1](#1)</sup>. By relying on compile-time annotation processing to generate code, you know that your JSON will parse and serialize faster than any other method available.
 
@@ -13,7 +13,7 @@ Don't believe it could improve upon Jackson Databind's or GSON's performance tha
 
 ![Benchmarks](docs/benchmarks.jpg)
 
-##Download
+## Download
 
 Note that Gradle is the only supported build configuration for LoganSquare. To add the library to your app's build.gradle file.
 
@@ -36,7 +36,7 @@ dependencies {
 ```
 For the curious, the buildscript and apply plugin lines add the [apt plugin](https://bitbucket.org/hvisser/android-apt), which is what allows us to do compile-time annotation processing. The first dependency is what tells Gradle to process your JSON annotations, and the second dependency is our tiny 19kb runtime library that interfaces with the generated code for you.
 
-##Usage
+## Usage
 
 Using LoganSquare is about as easy as it gets. Here are a few docs to get you started:
 
@@ -45,7 +45,7 @@ Using LoganSquare is about as easy as it gets. Here are a few docs to get you st
  * [Serializing to JSON](docs/Serializing.md)
  * [Supporting custom types](docs/TypeConverters.md)
 
-##Proguard
+## Proguard
 Like all libraries that generate dynamic code, Proguard might think some classes are unused and remove them. To prevent this, the following lines can be added to your proguard config file.
 
 ```
@@ -54,17 +54,17 @@ Like all libraries that generate dynamic code, Proguard might think some classes
 -keep class **$$JsonObjectMapper { *; }
 ```
 
-##Why LoganSquare?
+## Why LoganSquare?
 
 We're BlueLine Labs, a mobile app development company based in Chicago. We love this city so much that we named our company after the blue line of the iconic 'L.' And what's one of the most popular stops on the blue line? Well, that would be Logan Square of course. Does it have anything to do with JSON? Nope, but we're okay with that.
 
-##Props
+## Props
 
  * [Jackson's streaming API](https://github.com/FasterXML/jackson-core) for being a super-fast, awesome base for this project.
  * [Instagram's ig-json-parser](https://github.com/Instagram/ig-json-parser) for giving us the idea for this project.
  * [Jake Wharton's Butterknife](https://github.com/JakeWharton/butterknife) for being a great reference for annotation processing and code generation.
 
-##License
+## License
 
     Copyright 2015 BlueLine Labs, Inc.
 

--- a/docs/AnnotationsOnlyModel.md
+++ b/docs/AnnotationsOnlyModel.md
@@ -1,6 +1,6 @@
-##Annotating Every Field (Recommended)
+## Annotating Every Field (Recommended)
 
-###Sample Model
+### Sample Model
 
 ```java
 @JsonObject

--- a/docs/Models.md
+++ b/docs/Models.md
@@ -1,6 +1,6 @@
-##Model Creation
+## Model Creation
 
-###Sample Models
+### Sample Models
 
 LoganSquare provides a few robust ways to create your models. Sample models for each strategy are provided below:
 
@@ -11,12 +11,12 @@ LoganSquare provides a few robust ways to create your models. Sample models for 
  * [Include all public and package-local field AND accessors](PrivateFieldsAndAccessorsModel.md)
   * This uses the same concept as the above stretegy, but also includes any private fields that have both a getter and a setter.
 
-###Field Naming Policies
+### Field Naming Policies
 
 By default, LoganSquare assumes that the JSON field name will match your Java variable's name unless the `name` parameter has been used in the field's `@JsonField` annotation. This can be changed by passing another value into the `@JsonObject` annotation's `fieldNamingPolicy` variable. 
 
 Currently the only options are `FIELD_NAME`, which is the default described above, and `LOWER_CASE_WITH_UNDERSCORES`, which will cause LoganSquare to assume that your JSON fields are named the same as your java variable names, except converted to lower case with undercore notation instead of camel case.
 
-###Serializing Null Values
+### Serializing Null Values
 
 By default, LoganSquare will not serialize `null` values or collection elements into your JSON object. To change this, set the `@JsonObject` annotation's `serializeNullObjects` and/or `serializeNullCollectionElements` to `true`.

--- a/docs/Parsing.md
+++ b/docs/Parsing.md
@@ -1,4 +1,4 @@
-##Parsing JSON
+## Parsing JSON
 
 JSON can be parsed from an `InputStream` or a `String`. If you're getting your JSON directly from your networking library, you should be able to use an `InputStream` to avoid converting it to a String for no reason. Here's a sample:
 

--- a/docs/Parsing.md
+++ b/docs/Parsing.md
@@ -1,6 +1,6 @@
 ## Parsing JSON
 
-JSON can be parsed from an `InputStream` or a `String`. If you're getting your JSON directly from your networking library, you should be able to use an `InputStream` to avoid converting it to a String for no reason. Here's a sample:
+JSON can be parsed from an `InputStream` or a `String`. If you're getting your JSON directly from your networking library, you should be able to use an `InputStream` to avoid converting it to a `String` for no reason. Here's a sample:
 
 ```java
     // Parse from an InputStream

--- a/docs/PrivateFieldsAndAccessorsModel.md
+++ b/docs/PrivateFieldsAndAccessorsModel.md
@@ -1,6 +1,6 @@
-##Non-private Fields And Accessors Detection Policy
+## Non-private Fields And Accessors Detection Policy
 
-###Sample Model
+### Sample Model
 
 ```java
 /*

--- a/docs/PrivateFieldsModel.md
+++ b/docs/PrivateFieldsModel.md
@@ -1,6 +1,6 @@
-##Non-private Field Detection Policy
+## Non-private Field Detection Policy
 
-###Sample Model
+### Sample Model
 
 ```java
 /*

--- a/docs/Serializing.md
+++ b/docs/Serializing.md
@@ -1,4 +1,4 @@
-##Serializing JSON
+## Serializing JSON
 
 LoganSquare can serialize objects to an `OutputStream` or a `String`. Here's a sample:
 

--- a/docs/TypeConverters.md
+++ b/docs/TypeConverters.md
@@ -1,6 +1,6 @@
-##Type Support
+## Type Support
 
-###Types with Built-in Support
+### Types with Built-in Support
 
 By default, the following types are supported by LoganSquare:
 
@@ -30,7 +30,7 @@ Additionally, the following collections are supported:
  * LinkedHashMap 
 * Array (Not technically a Collection, but still supported. Note that Lists are preferred to arrays when possible.)
 
-###Support for Additional Types
+### Support for Additional Types
 
 Any Java object can be supported by LoganSquare, even if they don't fall into the above categories. To add support for your own types, you'll need to extend one of the built-in `TypeConverter` classes. You can register your custom type converters using one of the two following ways:
 
@@ -52,9 +52,9 @@ public class ModelObject {
 }
 ```
 
-###Example `TypeConverter`s
+### Example `TypeConverter`s
 
-####`TypeConverter` for a custom date format
+#### `TypeConverter` for a custom date format
 
 ```java
 public class TimeOnlyDateConverter extends DateTypeConverter {
@@ -72,7 +72,7 @@ public class TimeOnlyDateConverter extends DateTypeConverter {
 }
 ```
 
-####`TypeConverter` for an enum, where the JSON contains an int
+#### `TypeConverter` for an enum, where the JSON contains an int
 
 ```java
 public enum TestEnum {
@@ -92,7 +92,7 @@ public class TimeOnlyDateConverter extends IntBasedTypeConverter<TestEnum> {
 }
 ```
 
-####`TypeConverter` for an enum, where the JSON contains a String
+#### `TypeConverter` for an enum, where the JSON contains a String
 
 ```java
 public enum TestEnum {

--- a/docs/TypeConverters.md
+++ b/docs/TypeConverters.md
@@ -42,7 +42,7 @@ LoganSquare.registerTypeConverter(Date.class, new YourConverter());
 
 #### For `TypeConverter`s that should only be used for certain variables
 
-Hint: This method is especially useful for handling multiple Date formats!
+Hint: This method is especially useful for handling multiple `Date` formats!
 
 ```java
 @JsonObject
@@ -72,7 +72,7 @@ public class TimeOnlyDateConverter extends DateTypeConverter {
 }
 ```
 
-#### `TypeConverter` for an enum, where the JSON contains an int
+#### `TypeConverter` for an `enum`, where the JSON contains an int
 
 ```java
 public enum TestEnum {
@@ -92,7 +92,7 @@ public class TimeOnlyDateConverter extends IntBasedTypeConverter<TestEnum> {
 }
 ```
 
-#### `TypeConverter` for an enum, where the JSON contains a String
+#### `TypeConverter` for an `enum`, where the JSON contains a String
 
 ```java
 public enum TestEnum {

--- a/docs/TypeConverters.md
+++ b/docs/TypeConverters.md
@@ -5,30 +5,30 @@
 By default, the following types are supported by LoganSquare:
 
 * any object using the `@JsonObject` annotation
-* int and Integer
-* long and Long
-* float and Float
-* double and Double
-* boolean and Boolean
-* String
-* Date (if formatted using the ISO 8601 standard: `yyyy-MM-dd'T'HH:mm:ss.SSSZ`)
+* `int` and `Integer`
+* `long` and `Long`
+* `float` and `Float`
+* `double` and `Double`
+* `boolean` and `Boolean`
+* `String`
+* `Date` (if formatted using the ISO 8601 standard: `yyyy-MM-dd'T'HH:mm:ss.SSSZ`)
 
 Additionally, the following collections are supported:
 
-* Lists
- * ArrayList
- * LinkedList
-* Sets
- * HashSet 
-* Queues
- * ArrayDeque
-* Deques
- * ArrayDeque
-* Maps (with Strings as keys)
- * HashMap
- * TreeMap
- * LinkedHashMap 
-* Array (Not technically a Collection, but still supported. Note that Lists are preferred to arrays when possible.)
+* `List`s
+ * `ArrayList`
+ * `LinkedList`
+* `Set`s
+ * `HashSet` 
+* `Queue`s
+ * `ArrayDeque`
+* `Deque`s
+ * `ArrayDeque`
+* `Map`s (with `String`s as keys)
+ * `HashMap`
+ * `TreeMap`
+ * `LinkedHashMap` 
+* `Array` (Not technically a `Collection`, but still supported. Note that `List`s are preferred to arrays when possible.)
 
 ### Support for Additional Types
 


### PR DESCRIPTION
Headlines were broken in markdown when viewed on github.com.
Additionally I improved some code formatting in the documentation.