### PR TITLE
Enums parsing/serializing generator code

### DIFF
--- a/BenchmarkDemo/app/build.gradle
+++ b/BenchmarkDemo/app/build.gradle
@@ -39,9 +39,9 @@ dependencies {
     compile 'com.android.support:appcompat-v7:23.1.1'
 
     // LoganSquare annotation processor
-    apt 'com.bluelinelabs:logansquare-compiler:1.3.6'
+    apt 'com.bluelinelabs:logansquare-compiler:1.3.7'
     // LoganSquare runtime library
-    compile 'com.bluelinelabs:logansquare:1.3.6'
+    compile 'com.bluelinelabs:logansquare:1.3.7'
 
     // Jackson libraries for comparison
     compile 'com.fasterxml.jackson.core:jackson-databind:2.5.1'

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ buildscript {
 apply plugin: 'com.neenbedankt.android-apt'
 
 dependencies {
-    apt 'com.bluelinelabs:logansquare-compiler:1.3.6'
-    compile 'com.bluelinelabs:logansquare:1.3.6'
+    apt 'com.bluelinelabs:logansquare-compiler:1.3.7'
+    compile 'com.bluelinelabs:logansquare:1.3.7'
 }
 
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ allprojects {
     apply plugin: 'idea'
 
     group = 'com.bluelinelabs'
-    version = '1.3.6'
+    version = '1.3.7'
 }
 
 subprojects {

--- a/core/src/main/java/com/bluelinelabs/logansquare/Constants.java
+++ b/core/src/main/java/com/bluelinelabs/logansquare/Constants.java
@@ -5,4 +5,7 @@ public class Constants {
     /** The suffix that will be added to all generated classes */
     public static final String MAPPER_CLASS_SUFFIX = "$$JsonObjectMapper";
 
+    /** The suffix that will be added to all generated converter classes */
+    public static final String CONVERTER_CLASS_SUFFIX = "$$JsonTypeConverter";
+
 }

--- a/core/src/main/java/com/bluelinelabs/logansquare/annotation/JsonBooleanValue.java
+++ b/core/src/main/java/com/bluelinelabs/logansquare/annotation/JsonBooleanValue.java
@@ -1,0 +1,32 @@
+package com.bluelinelabs.logansquare.annotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.RetentionPolicy.CLASS;
+
+/**
+ * Declare that a enum value should be parsed/serialized.
+ * <pre><code>
+ * {@literal @}JsonEnum
+ * public enum MyEnum {
+ *
+ *     {@literal @}@JsonBooleanValue(true)
+ *     VALUE_FOR_TRUE,
+ *     {@literal @}@JsonBooleanValue(false)
+ *     VALUE_FOR_FALSE
+ *
+ * }
+ * </code></pre>
+ */
+@Target(FIELD)
+@Retention(CLASS)
+public @interface JsonBooleanValue {
+
+    /**
+     * The boolean representation of this enum value in JSON.
+     */
+    boolean value();
+
+}

--- a/core/src/main/java/com/bluelinelabs/logansquare/annotation/JsonEnum.java
+++ b/core/src/main/java/com/bluelinelabs/logansquare/annotation/JsonEnum.java
@@ -1,0 +1,12 @@
+package com.bluelinelabs.logansquare.annotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.CLASS;
+
+@Target(TYPE)
+@Retention(CLASS)
+public @interface JsonEnum {
+}

--- a/core/src/main/java/com/bluelinelabs/logansquare/annotation/JsonEnum.java
+++ b/core/src/main/java/com/bluelinelabs/logansquare/annotation/JsonEnum.java
@@ -6,7 +6,47 @@ import java.lang.annotation.Target;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.CLASS;
 
+/**
+ * Declare that a Java enum is parsable and serializable.
+ * <pre><code>
+ * {@literal @}JsonEnum
+ * public enum MyEnum {
+ *
+ *     {@literal @}@JsonStringValue("value_1")
+ *     VALUE_1,
+ *     {@literal @}@JsonStringValue("value_2")
+ *     VALUE_2,
+ *     {@literal @}@JsonNullValue
+ *     VALUE_NULL
+ *
+ * }
+ * </code></pre>
+ */
 @Target(TYPE)
 @Retention(CLASS)
 public @interface JsonEnum {
+
+    public enum ValueNamingPolicy {
+        /**
+         * Use the Java value's name, unless the 'value' parameter is
+         * passed into the @JsonStringValue, @JsonNumberValue or @jsonBooleanValue annotation
+         */
+        VALUE_NAME,
+
+        /**
+         * Use the Java value's name converted to lower case separated by
+         * underscores, unless the 'value' parameter is
+         * passed into the @JsonStringValue, @JsonNumberValue or @jsonBooleanValue annotation
+         */
+        LOWER_CASE_WITH_UNDERSCORES
+    }
+
+    /**
+     * Allows control over what value names LoganSquare expects in the JSON when parsing
+     * and how the values are named while serializing. By default, value names match
+     * the name of the Java value unless the 'value' parameter is
+     * passed into the value's @JsonStringValue, @JsonNumberValue or @jsonBooleanValue annotation
+     */
+    ValueNamingPolicy valueNamingPolicy() default ValueNamingPolicy.VALUE_NAME;
+
 }

--- a/core/src/main/java/com/bluelinelabs/logansquare/annotation/JsonNullValue.java
+++ b/core/src/main/java/com/bluelinelabs/logansquare/annotation/JsonNullValue.java
@@ -1,0 +1,31 @@
+package com.bluelinelabs.logansquare.annotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.RetentionPolicy.CLASS;
+
+/**
+ * Declare that a enum value should be parsed/serialized as null.
+ * So if enum contains value annotated with it
+ * then parser fill fields with that value instead of null
+ * and serializer will write null if field contains that value.
+ * <pre><code>
+ * {@literal @}JsonEnum
+ * public enum MyEnum {
+ *
+ *     {@literal @}@JsonNullValue
+ *     VALUE_EMPTY,
+ *     {@literal @}@JsonNumberValue(1)
+ *     VALUE_ONE,
+ *     {@literal @}@JsonNumberValue(2)
+ *     VALUE_TWO
+ *
+ * }
+ * </code></pre>
+ */
+@Target(FIELD)
+@Retention(CLASS)
+public @interface JsonNullValue {
+}

--- a/core/src/main/java/com/bluelinelabs/logansquare/annotation/JsonNumberValue.java
+++ b/core/src/main/java/com/bluelinelabs/logansquare/annotation/JsonNumberValue.java
@@ -1,0 +1,32 @@
+package com.bluelinelabs.logansquare.annotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.RetentionPolicy.CLASS;
+
+/**
+ * Declare that a enum value should be parsed/serialized.
+ * <pre><code>
+ * {@literal @}JsonEnum
+ * public enum MyEnum {
+ *
+ *     {@literal @}@JsonNumberValue(1)
+ *     VALUE_ONE,
+ *     {@literal @}@JsonNumberValue(2)
+ *     VALUE_TWO
+ *
+ * }
+ * </code></pre>
+ */
+@Target(FIELD)
+@Retention(CLASS)
+public @interface JsonNumberValue {
+
+    /**
+     * The number representation of this enum value in JSON.
+     */
+    long value();
+
+}

--- a/core/src/main/java/com/bluelinelabs/logansquare/annotation/JsonStringValue.java
+++ b/core/src/main/java/com/bluelinelabs/logansquare/annotation/JsonStringValue.java
@@ -1,0 +1,32 @@
+package com.bluelinelabs.logansquare.annotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.RetentionPolicy.CLASS;
+
+/**
+ * Declare that a enum value should be parsed/serialized.
+ * <pre><code>
+ * {@literal @}JsonEnum
+ * public enum MyEnum {
+ *
+ *     {@literal @}@JsonStringValue("value_1")
+ *     VALUE_1,
+ *     {@literal @}@JsonStringValue("value_2")
+ *     VALUE_2
+ *
+ * }
+ * </code></pre>
+ */
+@Target(FIELD)
+@Retention(CLASS)
+public @interface JsonStringValue {
+
+    /**
+     * The string representation of this enum value in JSON.
+     */
+    String value();
+
+}

--- a/core/src/main/java/com/bluelinelabs/logansquare/typeconverters/LongBasedTypeConverter.java
+++ b/core/src/main/java/com/bluelinelabs/logansquare/typeconverters/LongBasedTypeConverter.java
@@ -12,14 +12,14 @@ public abstract class LongBasedTypeConverter<T> implements TypeConverter<T> {
      *
      * @param l The long parsed from JSON.
      */
-    public abstract T getFromLong(long l);
+    public abstract T getFromLong(Long l);
 
     /**
      * Called to convert a an object of type T into a long.
      *
      * @param object The object being converted.
      */
-    public abstract long convertToLong(T object);
+    public abstract Long convertToLong(T object);
 
     @Override
     public T parse(JsonParser jsonParser) throws IOException {

--- a/processor/src/main/java/com/bluelinelabs/logansquare/processor/EnumConverterInjector.java
+++ b/processor/src/main/java/com/bluelinelabs/logansquare/processor/EnumConverterInjector.java
@@ -1,0 +1,120 @@
+package com.bluelinelabs.logansquare.processor;
+
+
+import com.bluelinelabs.logansquare.typeconverters.StringBasedTypeConverter;
+import com.squareup.javapoet.ClassName;
+import com.squareup.javapoet.JavaFile;
+import com.squareup.javapoet.MethodSpec;
+import com.squareup.javapoet.ParameterizedTypeName;
+import com.squareup.javapoet.TypeSpec;
+
+import java.util.Map;
+
+import javax.lang.model.element.Modifier;
+
+public class EnumConverterInjector implements Injector {
+
+    private static final String CONVERTER_FROM_VARIABLE_NAME = "string";
+    private static final String CONVERTER_TO_VARIABLE_NAME = "value";
+
+    private final JsonEnumHolder mJsonEnumHolder;
+
+    public EnumConverterInjector(JsonEnumHolder jsonEnumHolder) {
+        this.mJsonEnumHolder = jsonEnumHolder;
+    }
+
+    public String getJavaClassFile() {
+        try {
+            return JavaFile.builder(mJsonEnumHolder.packageName, getTypeSpec()).build().toString();
+        } catch (Exception e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+
+    private TypeSpec getTypeSpec() {
+        TypeSpec.Builder builder = TypeSpec.classBuilder(mJsonEnumHolder.injectedClassName).addModifiers(Modifier.PUBLIC, Modifier.FINAL);
+
+        builder.superclass(ParameterizedTypeName.get(ClassName.get(StringBasedTypeConverter.class), mJsonEnumHolder.objectTypeName));
+
+        builder.addMethod(createGetFromMethod(mJsonEnumHolder.getValuesMap()));
+        builder.addMethod(createConvertToMethod(mJsonEnumHolder.getValuesMap()));
+
+        return builder.build();
+    }
+
+    private MethodSpec createGetFromMethod(Map<String, String> valuesMap) {
+        MethodSpec.Builder builder = MethodSpec.methodBuilder("getFromString")
+                .addAnnotation(Override.class)
+                .addModifiers(Modifier.PUBLIC)
+                .returns(mJsonEnumHolder.objectTypeName)
+                .addParameter(String.class, CONVERTER_FROM_VARIABLE_NAME);
+
+        builder.beginControlFlow("if ($L == null)", CONVERTER_FROM_VARIABLE_NAME);
+        boolean nullEntryFound = false;
+        for (Map.Entry<String, String> entry : valuesMap.entrySet()) {
+            if (entry.getValue() == null) {
+                builder.addStatement("return $T.$L", mJsonEnumHolder.objectTypeName, entry.getKey());
+                nullEntryFound = true;
+            }
+        }
+        if (!nullEntryFound) {
+            builder.addStatement("return null");
+        }
+        builder.endControlFlow();
+
+        builder.beginControlFlow("switch ($L)", CONVERTER_FROM_VARIABLE_NAME);
+        for (Map.Entry<String, String> entry : valuesMap.entrySet()) {
+            if (entry.getValue() != null) {
+                builder.addStatement("case \"$L\": return $T.$L", entry.getValue(), mJsonEnumHolder.objectTypeName, entry.getKey());
+            }
+        }
+        builder.addStatement("default: throw new IllegalArgumentException($L)", CONVERTER_FROM_VARIABLE_NAME);
+        builder.endControlFlow();
+
+        return builder.build();
+    }
+
+    private MethodSpec createConvertToMethod(Map<String, String> valuesMap) {
+        MethodSpec.Builder builder = MethodSpec.methodBuilder("convertToString")
+                .addAnnotation(Override.class)
+                .addModifiers(Modifier.PUBLIC)
+                .returns(String.class)
+                .addParameter(mJsonEnumHolder.objectTypeName, CONVERTER_TO_VARIABLE_NAME);
+
+        String nullValue = null;
+        for (Map.Entry<String, String> entry : valuesMap.entrySet()) {
+            if (entry.getValue() == null) {
+                nullValue = entry.getKey();
+            }
+        }
+        if (nullValue == null) {
+            builder.beginControlFlow("if ($L == null)", CONVERTER_TO_VARIABLE_NAME);
+        } else {
+            builder.beginControlFlow("if ($L == null || $L == $T.$L)",
+                    CONVERTER_TO_VARIABLE_NAME, CONVERTER_TO_VARIABLE_NAME, mJsonEnumHolder.objectTypeName, nullValue);
+        }
+        builder.addStatement("return null");
+        builder.endControlFlow();
+
+        builder.beginControlFlow("switch ($L)", CONVERTER_TO_VARIABLE_NAME);
+        for (Map.Entry<String, String> entry : valuesMap.entrySet()) {
+            if (entry.getValue() != null) {
+                builder.addStatement("case $L: return \"$L\"", entry.getKey(), entry.getValue());
+            }
+        }
+        builder.addStatement("default: throw new IllegalArgumentException($L.name())", CONVERTER_TO_VARIABLE_NAME);
+        builder.endControlFlow();
+
+        return builder.build();
+    }
+
+    /*TODO: add like used types
+    private CodeBlock createStaticConstructor() {
+        CodeBlock.Builder builder = CodeBlock.builder();
+        builder.addStatement("$T.registerTypeConverter($T.class, new $L())", LoganSquare.class, mJsonEnumHolder.objectTypeName, mJsonEnumHolder.injectedClassName);
+        return builder.build();
+    }
+    */
+
+}

--- a/processor/src/main/java/com/bluelinelabs/logansquare/processor/EnumConverterInjector.java
+++ b/processor/src/main/java/com/bluelinelabs/logansquare/processor/EnumConverterInjector.java
@@ -130,6 +130,7 @@ public class EnumConverterInjector implements Injector {
         } else {
             builder.addStatement("$L.writeNull()", CONVERTER_JSON_GENERATOR_PARAMETER_NAME);
         }
+        builder.addStatement("return");
         builder.endControlFlow();
 
         builder.beginControlFlow("switch ($L)", CONVERTER_VALUE_PARAMETER_NAME);

--- a/processor/src/main/java/com/bluelinelabs/logansquare/processor/Injector.java
+++ b/processor/src/main/java/com/bluelinelabs/logansquare/processor/Injector.java
@@ -1,0 +1,8 @@
+package com.bluelinelabs.logansquare.processor;
+
+
+public interface Injector {
+
+    String getJavaClassFile();
+
+}

--- a/processor/src/main/java/com/bluelinelabs/logansquare/processor/JsonAnnotationProcessor.java
+++ b/processor/src/main/java/com/bluelinelabs/logansquare/processor/JsonAnnotationProcessor.java
@@ -30,6 +30,7 @@ public class JsonAnnotationProcessor extends AbstractProcessor {
     private Filer mFiler;
     private List<Processor> mProcessors;
     private Map<String, JsonObjectHolder> mJsonObjectMap;
+    private Map<String, JsonEnumHolder> mJsonEnumMap;
 
     @Override
     public synchronized void init(ProcessingEnvironment env) {
@@ -60,7 +61,7 @@ public class JsonAnnotationProcessor extends AbstractProcessor {
     public boolean process(Set<? extends TypeElement> elements, RoundEnvironment env) {
         try {
             for (Processor processor : mProcessors) {
-                processor.findAndParseObjects(env, mJsonObjectMap, mElementUtils, mTypeUtils);
+                processor.findAndParseObjects(env, mJsonObjectMap, mJsonEnumMap, mElementUtils, mTypeUtils);
             }
 
             for (Map.Entry<String, JsonObjectHolder> entry : mJsonObjectMap.entrySet()) {

--- a/processor/src/main/java/com/bluelinelabs/logansquare/processor/JsonAnnotationProcessor.java
+++ b/processor/src/main/java/com/bluelinelabs/logansquare/processor/JsonAnnotationProcessor.java
@@ -102,7 +102,7 @@ public class JsonAnnotationProcessor extends AbstractProcessor {
             writer.flush();
             writer.close();
         } catch (IOException e) {
-            error(fqcn, "Exception occurred while attempting to write converter for enum %s. Exception message: %s", fqcn, e.getMessage());
+            error(fqcn, "Exception occurred while attempting to write code for %s. Exception message: %s", fqcn, e.getMessage());
         }
     }
 

--- a/processor/src/main/java/com/bluelinelabs/logansquare/processor/JsonEnumHolder.java
+++ b/processor/src/main/java/com/bluelinelabs/logansquare/processor/JsonEnumHolder.java
@@ -1,0 +1,18 @@
+package com.bluelinelabs.logansquare.processor;
+
+import java.util.Collections;
+import java.util.Map;
+
+public class JsonEnumHolder {
+
+    private final Map<String, String> valuesMap;
+
+    private JsonEnumHolder(final Map<String, String> valuesMap) {
+        this.valuesMap = valuesMap;
+    }
+
+    public Map<String, String> getValuesMap() {
+        return Collections.unmodifiableMap(valuesMap);
+    }
+
+}

--- a/processor/src/main/java/com/bluelinelabs/logansquare/processor/JsonEnumHolder.java
+++ b/processor/src/main/java/com/bluelinelabs/logansquare/processor/JsonEnumHolder.java
@@ -2,7 +2,6 @@ package com.bluelinelabs.logansquare.processor;
 
 import com.squareup.javapoet.TypeName;
 
-import java.util.Collections;
 import java.util.Map;
 
 public class JsonEnumHolder {
@@ -10,7 +9,8 @@ public class JsonEnumHolder {
     public final String packageName;
     public final String injectedClassName;
     public final TypeName objectTypeName;
-    public final Map<String, String> valuesMap;
+    public final ValueType valuesType;
+    public final Map<String, Object> valuesMap;
 
     public boolean fileCreated;
 
@@ -18,18 +18,36 @@ public class JsonEnumHolder {
         this.packageName = builder.packageName;
         this.injectedClassName = builder.injectedClassName;
         this.objectTypeName = builder.objectTypeName;
+        this.valuesType = builder.valuesType;
         this.valuesMap = builder.valuesMap;
     }
 
-    public Map<String, String> getValuesMap() {
-        return Collections.unmodifiableMap(valuesMap);
+    public enum ValueType {
+
+        STRING(String.class, "getValueAsString", "writeStringField", "writeString"),
+        NUMBER(long.class, "getValueAsLong", "writeNumberField", "writeNumber"),
+        BOOLEAN(boolean.class, "getValueAsBoolean", "writeBooleanField", "writeBoolean");
+
+        public final Class enumValueClass;
+        public final String getFromMethodName;
+        public final String writeToFieldMethodName;
+        public final String writeMethodName;
+
+        ValueType(Class enumValueClass, String getFromMethodName, String writeToFieldMethodName, String writeMethodName) {
+            this.enumValueClass = enumValueClass;
+            this.getFromMethodName = getFromMethodName;
+            this.writeToFieldMethodName = writeToFieldMethodName;
+            this.writeMethodName = writeMethodName;
+        }
+
     }
 
     public static class JsonEnumHolderBuilder {
         private String packageName;
         private String injectedClassName;
         private TypeName objectTypeName;
-        private Map<String, String> valuesMap;
+        private ValueType valuesType;
+        private Map<String, Object> valuesMap;
 
         public JsonEnumHolderBuilder setPackageName(String packageName) {
             this.packageName = packageName;
@@ -46,7 +64,8 @@ public class JsonEnumHolder {
             return this;
         }
 
-        public JsonEnumHolderBuilder setValuesMap(Map<String, String> valuesMap) {
+        public JsonEnumHolderBuilder setValuesMap(ValueType valuesType, Map<String, Object> valuesMap) {
+            this.valuesType = valuesType;
             this.valuesMap = valuesMap;
             return this;
         }

--- a/processor/src/main/java/com/bluelinelabs/logansquare/processor/JsonEnumHolder.java
+++ b/processor/src/main/java/com/bluelinelabs/logansquare/processor/JsonEnumHolder.java
@@ -1,18 +1,60 @@
 package com.bluelinelabs.logansquare.processor;
 
+import com.squareup.javapoet.TypeName;
+
 import java.util.Collections;
 import java.util.Map;
 
 public class JsonEnumHolder {
 
-    private final Map<String, String> valuesMap;
+    public final String packageName;
+    public final String injectedClassName;
+    public final TypeName objectTypeName;
+    public final Map<String, String> valuesMap;
 
-    private JsonEnumHolder(final Map<String, String> valuesMap) {
-        this.valuesMap = valuesMap;
+    public boolean fileCreated;
+
+    private JsonEnumHolder(JsonEnumHolderBuilder builder) {
+        this.packageName = builder.packageName;
+        this.injectedClassName = builder.injectedClassName;
+        this.objectTypeName = builder.objectTypeName;
+        this.valuesMap = builder.valuesMap;
     }
 
     public Map<String, String> getValuesMap() {
         return Collections.unmodifiableMap(valuesMap);
+    }
+
+    public static class JsonEnumHolderBuilder {
+        private String packageName;
+        private String injectedClassName;
+        private TypeName objectTypeName;
+        private Map<String, String> valuesMap;
+
+        public JsonEnumHolderBuilder setPackageName(String packageName) {
+            this.packageName = packageName;
+            return this;
+        }
+
+        public JsonEnumHolderBuilder setInjectedClassName(String injectedClassName) {
+            this.injectedClassName = injectedClassName;
+            return this;
+        }
+
+        public JsonEnumHolderBuilder setObjectTypeName(TypeName objectTypeName) {
+            this.objectTypeName = objectTypeName;
+            return this;
+        }
+
+        public JsonEnumHolderBuilder setValuesMap(Map<String, String> valuesMap) {
+            this.valuesMap = valuesMap;
+            return this;
+        }
+
+        public JsonEnumHolder build() {
+            return new JsonEnumHolder(this);
+        }
+
     }
 
 }

--- a/processor/src/main/java/com/bluelinelabs/logansquare/processor/ObjectMapperInjector.java
+++ b/processor/src/main/java/com/bluelinelabs/logansquare/processor/ObjectMapperInjector.java
@@ -33,7 +33,7 @@ import javax.lang.model.element.Modifier;
 import javax.lang.model.element.TypeParameterElement;
 import javax.lang.model.type.TypeVariable;
 
-public class ObjectMapperInjector {
+public class ObjectMapperInjector implements Injector {
 
     public static final String PARENT_OBJECT_MAPPER_VARIABLE_NAME = "parentObjectMapper";
     public static final String JSON_PARSER_VARIABLE_NAME = "jsonParser";
@@ -45,6 +45,7 @@ public class ObjectMapperInjector {
         mJsonObjectHolder = jsonObjectHolder;
     }
 
+    @Override
     public String getJavaClassFile() {
         try {
             return JavaFile.builder(mJsonObjectHolder.packageName, getTypeSpec()).build().toString();

--- a/processor/src/main/java/com/bluelinelabs/logansquare/processor/ObjectMapperInjector.java
+++ b/processor/src/main/java/com/bluelinelabs/logansquare/processor/ObjectMapperInjector.java
@@ -57,7 +57,7 @@ public class ObjectMapperInjector {
     private TypeSpec getTypeSpec() {
         TypeSpec.Builder builder = TypeSpec.classBuilder(mJsonObjectHolder.injectedClassName).addModifiers(Modifier.PUBLIC, Modifier.FINAL);
 
-        builder.addAnnotation(AnnotationSpec.builder(SuppressWarnings.class).addMember("value", "\"unsafe,unchecked\"").build());
+        builder.addAnnotation(AnnotationSpec.builder(SuppressWarnings.class).addMember("value", "{\"unsafe\", \"unchecked\"}").build());
 
         builder.superclass(ParameterizedTypeName.get(ClassName.get(JsonMapper.class), mJsonObjectHolder.objectTypeName));
 

--- a/processor/src/main/java/com/bluelinelabs/logansquare/processor/TextUtils.java
+++ b/processor/src/main/java/com/bluelinelabs/logansquare/processor/TextUtils.java
@@ -29,6 +29,15 @@ public class TextUtils {
         return sb.toString();
     }
 
+    public static boolean containsLowerCaseSymbols(String string) {
+        for (char c : string.toCharArray()) {
+            if (c >= 'a' && c <= 'z') {
+                return true;
+            }
+        }
+        return false;
+    }
+
     public static String toLowerCaseWithUnderscores(String className) {
         StringBuilder sb = new StringBuilder();
         for (char c : className.toCharArray()) {

--- a/processor/src/main/java/com/bluelinelabs/logansquare/processor/TypeUtils.java
+++ b/processor/src/main/java/com/bluelinelabs/logansquare/processor/TypeUtils.java
@@ -3,8 +3,11 @@ package com.bluelinelabs.logansquare.processor;
 import com.bluelinelabs.logansquare.Constants;
 import com.squareup.javapoet.ClassName;
 
+import java.util.ArrayList;
 import java.util.List;
 
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeMirror;
@@ -19,6 +22,11 @@ public class TypeUtils {
     public static String getInjectedFQCN(TypeElement type, Elements elements) {
         String packageName = elements.getPackageOf(type).getQualifiedName().toString();
         return packageName + "." + getSimpleClassName(type, packageName) + Constants.MAPPER_CLASS_SUFFIX;
+    }
+
+    public static String getInjectedConverterFQCN(TypeElement type, Elements elements) {
+        String packageName = elements.getPackageOf(type).getQualifiedName().toString();
+        return packageName + "." + getSimpleClassName(type, packageName) + Constants.CONVERTER_CLASS_SUFFIX;
     }
 
     public static String getInjectedFQCN(ClassName className) {
@@ -41,4 +49,15 @@ public class TypeUtils {
         DeclaredType declaredType = (DeclaredType)typeMirror;
         return (List<TypeMirror>)declaredType.getTypeArguments();
     }
+
+    public static List<Element> getEnumValues(Element type) {
+        final List<Element> result = new ArrayList<>();
+        for (Element enclosedElement : type.getEnclosedElements()) {
+            if (enclosedElement.getKind() == ElementKind.ENUM_CONSTANT) {
+                result.add(enclosedElement);
+            }
+        }
+        return result;
+    }
+
 }

--- a/processor/src/main/java/com/bluelinelabs/logansquare/processor/processor/JsonEnumProcessor.java
+++ b/processor/src/main/java/com/bluelinelabs/logansquare/processor/processor/JsonEnumProcessor.java
@@ -1,11 +1,16 @@
 package com.bluelinelabs.logansquare.processor.processor;
 
+import com.bluelinelabs.logansquare.Constants;
 import com.bluelinelabs.logansquare.annotation.JsonEnum;
 import com.bluelinelabs.logansquare.processor.JsonEnumHolder;
 import com.bluelinelabs.logansquare.processor.JsonObjectHolder;
+import com.bluelinelabs.logansquare.processor.TypeUtils;
+import com.squareup.javapoet.TypeName;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import javax.annotation.processing.ProcessingEnvironment;
@@ -15,6 +20,7 @@ import javax.lang.model.element.TypeElement;
 import javax.lang.model.util.Elements;
 import javax.lang.model.util.Types;
 
+import static com.bluelinelabs.logansquare.processor.JsonEnumHolder.JsonEnumHolderBuilder;
 import static javax.lang.model.element.Modifier.PRIVATE;
 
 public class JsonEnumProcessor extends Processor {
@@ -43,10 +49,35 @@ public class JsonEnumProcessor extends Processor {
     }
 
     private void processJsonEnumAnnotation(Element element, Map<String, JsonEnumHolder> jsonEnumMap, Elements elements, Types types) {
-        TypeElement typeElement = (TypeElement)element;
+        TypeElement typeElement = (TypeElement) element;
+        final List<Element> enumValues = TypeUtils.getEnumValues(element);
 
         if (element.getModifiers().contains(PRIVATE)) {
             error(element, "%s: %s annotation can't be used on private enums.", typeElement.getQualifiedName(), JsonEnum.class.getSimpleName());
+        }
+        if (enumValues.isEmpty()) {
+            error(element, "%s: %s annotation can't be used on enums with no values.", typeElement.getQualifiedName(), JsonEnum.class.getSimpleName());
+        }
+
+        JsonEnumHolder holder = jsonEnumMap.get(TypeUtils.getInjectedConverterFQCN(typeElement, elements));
+        if (holder == null) {
+            String packageName = elements.getPackageOf(typeElement).getQualifiedName().toString();
+            String objectClassName = TypeUtils.getSimpleClassName(typeElement, packageName);
+            String injectedSimpleClassName = objectClassName + Constants.CONVERTER_CLASS_SUFFIX;
+
+            Map<String, String> valuesMap = new HashMap<>();
+            for (Element enumValue : enumValues) {
+                valuesMap.put(enumValue.getSimpleName().toString(), enumValue.getSimpleName().toString().toLowerCase());
+            }
+
+            holder = new JsonEnumHolderBuilder()
+                    .setPackageName(packageName)
+                    .setInjectedClassName(injectedSimpleClassName)
+                    .setObjectTypeName(TypeName.get(typeElement.asType()))
+                    .setValuesMap(valuesMap)
+                    .build();
+
+            jsonEnumMap.put(TypeUtils.getInjectedConverterFQCN(typeElement, elements), holder);
         }
     }
 

--- a/processor/src/main/java/com/bluelinelabs/logansquare/processor/processor/JsonEnumProcessor.java
+++ b/processor/src/main/java/com/bluelinelabs/logansquare/processor/processor/JsonEnumProcessor.java
@@ -122,11 +122,16 @@ public class JsonEnumProcessor extends Processor {
         if (enumValue.getAnnotation(JsonNullValue.class) != null) {
             return new Pair<ValueType, Object>(null, null);
         }
-        switch (valueNamingPolicy){
+        String valueString = enumValue.getSimpleName().toString();
+        switch (valueNamingPolicy) {
             case VALUE_NAME:
-                return new Pair<ValueType, Object>(ValueType.STRING, enumValue.getSimpleName().toString());
+                return new Pair<ValueType, Object>(ValueType.STRING, valueString);
             case LOWER_CASE_WITH_UNDERSCORES:
-                return new Pair<ValueType, Object>(ValueType.STRING, TextUtils.toLowerCaseWithUnderscores(enumValue.getSimpleName().toString()));
+                if (TextUtils.containsLowerCaseSymbols(valueString)) {
+                    return new Pair<>(ValueType.STRING, TextUtils.toLowerCaseWithUnderscores(valueString));
+                } else {
+                    return new Pair<>(ValueType.STRING, valueString.toLowerCase());
+                }
             default:
                 throw new IllegalStateException("Unknown valueNamingPolicy: " + valueNamingPolicy);
         }

--- a/processor/src/main/java/com/bluelinelabs/logansquare/processor/processor/JsonEnumProcessor.java
+++ b/processor/src/main/java/com/bluelinelabs/logansquare/processor/processor/JsonEnumProcessor.java
@@ -1,0 +1,53 @@
+package com.bluelinelabs.logansquare.processor.processor;
+
+import com.bluelinelabs.logansquare.annotation.JsonEnum;
+import com.bluelinelabs.logansquare.processor.JsonEnumHolder;
+import com.bluelinelabs.logansquare.processor.JsonObjectHolder;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.Map;
+
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.annotation.processing.RoundEnvironment;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.util.Elements;
+import javax.lang.model.util.Types;
+
+import static javax.lang.model.element.Modifier.PRIVATE;
+
+public class JsonEnumProcessor extends Processor {
+
+    public JsonEnumProcessor(ProcessingEnvironment processingEnv) {
+        super(processingEnv);
+    }
+
+    @Override
+    public Class getAnnotation() {
+        return JsonEnum.class;
+    }
+
+    @Override
+    public void findAndParseObjects(RoundEnvironment env, Map<String, JsonObjectHolder> jsonObjectMap, Map<String, JsonEnumHolder> jsonEnumMap, Elements elements, Types types) {
+        for (Element element : env.getElementsAnnotatedWith(JsonEnum.class)) {
+            try {
+                processJsonEnumAnnotation(element, jsonEnumMap, elements, types);
+            } catch (Exception e) {
+                StringWriter stackTrace = new StringWriter();
+                e.printStackTrace(new PrintWriter(stackTrace));
+
+                error(element, "Unable to generate injector for %s. Stack trace incoming:\n%s", JsonEnum.class, stackTrace.toString());
+            }
+        }
+    }
+
+    private void processJsonEnumAnnotation(Element element, Map<String, JsonEnumHolder> jsonEnumMap, Elements elements, Types types) {
+        TypeElement typeElement = (TypeElement)element;
+
+        if (element.getModifiers().contains(PRIVATE)) {
+            error(element, "%s: %s annotation can't be used on private enums.", typeElement.getQualifiedName(), JsonEnum.class.getSimpleName());
+        }
+    }
+
+}

--- a/processor/src/main/java/com/bluelinelabs/logansquare/processor/processor/JsonEnumProcessor.java
+++ b/processor/src/main/java/com/bluelinelabs/logansquare/processor/processor/JsonEnumProcessor.java
@@ -128,9 +128,9 @@ public class JsonEnumProcessor extends Processor {
                 return new Pair<ValueType, Object>(ValueType.STRING, valueString);
             case LOWER_CASE_WITH_UNDERSCORES:
                 if (TextUtils.containsLowerCaseSymbols(valueString)) {
-                    return new Pair<>(ValueType.STRING, TextUtils.toLowerCaseWithUnderscores(valueString));
+                    return new Pair<ValueType, Object>(ValueType.STRING, TextUtils.toLowerCaseWithUnderscores(valueString));
                 } else {
-                    return new Pair<>(ValueType.STRING, valueString.toLowerCase());
+                    return new Pair<ValueType, Object>(ValueType.STRING, valueString.toLowerCase());
                 }
             default:
                 throw new IllegalStateException("Unknown valueNamingPolicy: " + valueNamingPolicy);

--- a/processor/src/main/java/com/bluelinelabs/logansquare/processor/processor/JsonEnumProcessor.java
+++ b/processor/src/main/java/com/bluelinelabs/logansquare/processor/processor/JsonEnumProcessor.java
@@ -1,14 +1,20 @@
 package com.bluelinelabs.logansquare.processor.processor;
 
 import com.bluelinelabs.logansquare.Constants;
+import com.bluelinelabs.logansquare.annotation.JsonBooleanValue;
 import com.bluelinelabs.logansquare.annotation.JsonEnum;
+import com.bluelinelabs.logansquare.annotation.JsonNullValue;
+import com.bluelinelabs.logansquare.annotation.JsonNumberValue;
+import com.bluelinelabs.logansquare.annotation.JsonStringValue;
 import com.bluelinelabs.logansquare.processor.JsonEnumHolder;
 import com.bluelinelabs.logansquare.processor.JsonObjectHolder;
+import com.bluelinelabs.logansquare.processor.TextUtils;
 import com.bluelinelabs.logansquare.processor.TypeUtils;
 import com.squareup.javapoet.TypeName;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -20,7 +26,10 @@ import javax.lang.model.element.TypeElement;
 import javax.lang.model.util.Elements;
 import javax.lang.model.util.Types;
 
+import javafx.util.Pair;
+
 import static com.bluelinelabs.logansquare.processor.JsonEnumHolder.JsonEnumHolderBuilder;
+import static com.bluelinelabs.logansquare.processor.JsonEnumHolder.ValueType;
 import static javax.lang.model.element.Modifier.PRIVATE;
 
 public class JsonEnumProcessor extends Processor {
@@ -38,7 +47,7 @@ public class JsonEnumProcessor extends Processor {
     public void findAndParseObjects(RoundEnvironment env, Map<String, JsonObjectHolder> jsonObjectMap, Map<String, JsonEnumHolder> jsonEnumMap, Elements elements, Types types) {
         for (Element element : env.getElementsAnnotatedWith(JsonEnum.class)) {
             try {
-                processJsonEnumAnnotation(element, jsonEnumMap, elements, types);
+                processJsonEnumAnnotation(element, jsonEnumMap, elements);
             } catch (Exception e) {
                 StringWriter stackTrace = new StringWriter();
                 e.printStackTrace(new PrintWriter(stackTrace));
@@ -48,7 +57,7 @@ public class JsonEnumProcessor extends Processor {
         }
     }
 
-    private void processJsonEnumAnnotation(Element element, Map<String, JsonEnumHolder> jsonEnumMap, Elements elements, Types types) {
+    private void processJsonEnumAnnotation(Element element, Map<String, JsonEnumHolder> jsonEnumMap, Elements elements) {
         TypeElement typeElement = (TypeElement) element;
         final List<Element> enumValues = TypeUtils.getEnumValues(element);
 
@@ -65,19 +74,74 @@ public class JsonEnumProcessor extends Processor {
             String objectClassName = TypeUtils.getSimpleClassName(typeElement, packageName);
             String injectedSimpleClassName = objectClassName + Constants.CONVERTER_CLASS_SUFFIX;
 
-            Map<String, String> valuesMap = new HashMap<>();
+            JsonEnum annotation = element.getAnnotation(JsonEnum.class);
+
+            Map<String, Object> valuesMap = new HashMap<>();
+            ValueType valueType = null;
             for (Element enumValue : enumValues) {
-                valuesMap.put(enumValue.getSimpleName().toString(), enumValue.getSimpleName().toString().toLowerCase());
+                Pair<ValueType, Object> valueInfo = extractObjectFromEnumValue(enumValue, annotation.valueNamingPolicy());
+                if (valueInfo.getKey() != null) {
+                    if (valueType == null) {
+                        valueType = valueInfo.getKey();
+                    }
+                    if (valueInfo.getKey() != valueType) {
+                        error(element, "%s: %s enum value type %s at %s conflicts with previously declared type %s.", typeElement.getQualifiedName(), valueInfo.getKey(), enumValue.getSimpleName(), valueType);
+                    }
+                }
+                valuesMap.put(enumValue.getSimpleName().toString(), valueInfo.getValue());
+            }
+            checkValuesForDuplicates(element, typeElement, valuesMap);
+            if (valueType == null) {
+                error(element, "%s: can't recognize type of values (only null value).", typeElement.getQualifiedName());
             }
 
             holder = new JsonEnumHolderBuilder()
                     .setPackageName(packageName)
                     .setInjectedClassName(injectedSimpleClassName)
                     .setObjectTypeName(TypeName.get(typeElement.asType()))
-                    .setValuesMap(valuesMap)
+                    .setValuesMap(valueType, valuesMap)
                     .build();
 
             jsonEnumMap.put(TypeUtils.getInjectedConverterFQCN(typeElement, elements), holder);
+        }
+    }
+
+    private Pair<ValueType, Object> extractObjectFromEnumValue(Element enumValue, JsonEnum.ValueNamingPolicy valueNamingPolicy) {
+        JsonStringValue stringAnnotation = enumValue.getAnnotation(JsonStringValue.class);
+        if (stringAnnotation != null) {
+            return new Pair<>(ValueType.STRING, stringAnnotation.value());
+        }
+        JsonNumberValue numberAnnotation = enumValue.getAnnotation(JsonNumberValue.class);
+        if (numberAnnotation != null) {
+            return new Pair<>(ValueType.NUMBER, numberAnnotation.value());
+        }
+        JsonBooleanValue booleanAnnotation = enumValue.getAnnotation(JsonBooleanValue.class);
+        if (booleanAnnotation != null) {
+            return new Pair<>(ValueType.BOOLEAN, booleanAnnotation.value());
+        }
+        if (enumValue.getAnnotation(JsonNullValue.class) != null) {
+            return new Pair<>(null, null);
+        }
+        switch (valueNamingPolicy){
+            case VALUE_NAME:
+                return new Pair<>(ValueType.STRING, enumValue.getSimpleName().toString());
+            case LOWER_CASE_WITH_UNDERSCORES:
+                return new Pair<>(ValueType.STRING, TextUtils.toLowerCaseWithUnderscores(enumValue.getSimpleName().toString()));
+            default:
+                throw new IllegalStateException("Unknown valueNamingPolicy: " + valueNamingPolicy);
+        }
+    }
+
+    private void checkValuesForDuplicates(Element element, TypeElement typeElement, Map<String, Object> valuesMap) {
+        ArrayList<Object> values = new ArrayList<>(valuesMap.values());
+        for (int i = 0; i < values.size(); i++) {
+            for (int j = i + 1; j < values.size(); j++) {
+                Object firstValue = values.get(i);
+                Object secondValue = values.get(j);
+                if (firstValue == secondValue || (firstValue != null && firstValue.equals(secondValue))) {
+                    error(element, "%s contains duplicate values: %s.", typeElement.getQualifiedName(), firstValue);
+                }
+            }
         }
     }
 

--- a/processor/src/main/java/com/bluelinelabs/logansquare/processor/processor/JsonEnumProcessor.java
+++ b/processor/src/main/java/com/bluelinelabs/logansquare/processor/processor/JsonEnumProcessor.java
@@ -109,24 +109,24 @@ public class JsonEnumProcessor extends Processor {
     private Pair<ValueType, Object> extractObjectFromEnumValue(Element enumValue, JsonEnum.ValueNamingPolicy valueNamingPolicy) {
         JsonStringValue stringAnnotation = enumValue.getAnnotation(JsonStringValue.class);
         if (stringAnnotation != null) {
-            return new Pair<>(ValueType.STRING, stringAnnotation.value());
+            return new Pair<ValueType, Object>(ValueType.STRING, stringAnnotation.value());
         }
         JsonNumberValue numberAnnotation = enumValue.getAnnotation(JsonNumberValue.class);
         if (numberAnnotation != null) {
-            return new Pair<>(ValueType.NUMBER, numberAnnotation.value());
+            return new Pair<ValueType, Object>(ValueType.NUMBER, numberAnnotation.value());
         }
         JsonBooleanValue booleanAnnotation = enumValue.getAnnotation(JsonBooleanValue.class);
         if (booleanAnnotation != null) {
-            return new Pair<>(ValueType.BOOLEAN, booleanAnnotation.value());
+            return new Pair<ValueType, Object>(ValueType.BOOLEAN, booleanAnnotation.value());
         }
         if (enumValue.getAnnotation(JsonNullValue.class) != null) {
-            return new Pair<>(null, null);
+            return new Pair<ValueType, Object>(null, null);
         }
         switch (valueNamingPolicy){
             case VALUE_NAME:
-                return new Pair<>(ValueType.STRING, enumValue.getSimpleName().toString());
+                return new Pair<ValueType, Object>(ValueType.STRING, enumValue.getSimpleName().toString());
             case LOWER_CASE_WITH_UNDERSCORES:
-                return new Pair<>(ValueType.STRING, TextUtils.toLowerCaseWithUnderscores(enumValue.getSimpleName().toString()));
+                return new Pair<ValueType, Object>(ValueType.STRING, TextUtils.toLowerCaseWithUnderscores(enumValue.getSimpleName().toString()));
             default:
                 throw new IllegalStateException("Unknown valueNamingPolicy: " + valueNamingPolicy);
         }

--- a/processor/src/main/java/com/bluelinelabs/logansquare/processor/processor/JsonEnumValueProcessor.java
+++ b/processor/src/main/java/com/bluelinelabs/logansquare/processor/processor/JsonEnumValueProcessor.java
@@ -1,0 +1,47 @@
+package com.bluelinelabs.logansquare.processor.processor;
+
+import com.bluelinelabs.logansquare.annotation.JsonEnum;
+import com.bluelinelabs.logansquare.processor.JsonEnumHolder;
+import com.bluelinelabs.logansquare.processor.JsonObjectHolder;
+
+import java.lang.annotation.Annotation;
+import java.util.Map;
+
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.annotation.processing.RoundEnvironment;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.util.Elements;
+import javax.lang.model.util.Types;
+
+public class JsonEnumValueProcessor<T extends Annotation> extends Processor {
+
+    private final Class<T> annotationClass;
+
+    protected JsonEnumValueProcessor(Class<T> annotationClass, ProcessingEnvironment processingEnv) {
+        super(processingEnv);
+        this.annotationClass=annotationClass;
+    }
+
+    @Override
+    public Class<T> getAnnotation() {
+        return annotationClass;
+    }
+
+    @Override
+    public void findAndParseObjects(RoundEnvironment env, Map<String, JsonObjectHolder> jsonObjectMap, Map<String, JsonEnumHolder> jsonEnumMap, Elements elements, Types types) {
+        for (Element element : env.getElementsAnnotatedWith(annotationClass)) {
+            TypeElement enclosingElement = (TypeElement) element.getEnclosingElement();
+
+            Annotation objectAnnotation = enclosingElement.getAnnotation(JsonEnum.class);
+            if (objectAnnotation == null) {
+                error(enclosingElement, "%s: @%s values can only be in classes annotated with @%s.", enclosingElement.getQualifiedName(), annotationClass.getSimpleName(), JsonEnum.class.getSimpleName());
+            }
+            if(element.getKind() != ElementKind.ENUM_CONSTANT){
+                error(element, "%s: @%s annotation can only be used on enum values.", enclosingElement.getQualifiedName(), annotationClass.getSimpleName());
+            }
+        }
+    }
+
+}

--- a/processor/src/main/java/com/bluelinelabs/logansquare/processor/processor/JsonFieldProcessor.java
+++ b/processor/src/main/java/com/bluelinelabs/logansquare/processor/processor/JsonFieldProcessor.java
@@ -4,6 +4,7 @@ import com.bluelinelabs.logansquare.annotation.JsonField;
 import com.bluelinelabs.logansquare.annotation.JsonIgnore;
 import com.bluelinelabs.logansquare.annotation.JsonIgnore.IgnorePolicy;
 import com.bluelinelabs.logansquare.annotation.JsonObject;
+import com.bluelinelabs.logansquare.processor.JsonEnumHolder;
 import com.bluelinelabs.logansquare.processor.JsonFieldHolder;
 import com.bluelinelabs.logansquare.processor.JsonObjectHolder;
 import com.bluelinelabs.logansquare.processor.TextUtils;
@@ -42,7 +43,7 @@ public class JsonFieldProcessor extends Processor {
     }
 
     @Override
-    public void findAndParseObjects(RoundEnvironment env, Map<String, JsonObjectHolder> jsonObjectMap, Elements elements, Types types) {
+    public void findAndParseObjects(RoundEnvironment env, Map<String, JsonObjectHolder> jsonObjectMap, Map<String, JsonEnumHolder> jsonEnumMap, Elements elements, Types types) {
         for (Element element : env.getElementsAnnotatedWith(JsonField.class)) {
             try {
                 processJsonFieldAnnotation(element, jsonObjectMap, elements, types);

--- a/processor/src/main/java/com/bluelinelabs/logansquare/processor/processor/JsonObjectProcessor.java
+++ b/processor/src/main/java/com/bluelinelabs/logansquare/processor/processor/JsonObjectProcessor.java
@@ -5,6 +5,7 @@ import com.bluelinelabs.logansquare.annotation.JsonIgnore;
 import com.bluelinelabs.logansquare.annotation.JsonIgnore.IgnorePolicy;
 import com.bluelinelabs.logansquare.annotation.JsonObject;
 import com.bluelinelabs.logansquare.annotation.JsonObject.FieldDetectionPolicy;
+import com.bluelinelabs.logansquare.processor.JsonEnumHolder;
 import com.bluelinelabs.logansquare.processor.JsonFieldHolder;
 import com.bluelinelabs.logansquare.processor.JsonObjectHolder;
 import com.bluelinelabs.logansquare.processor.JsonObjectHolder.JsonObjectHolderBuilder;
@@ -48,7 +49,7 @@ public class JsonObjectProcessor extends Processor {
     }
 
     @Override
-    public void findAndParseObjects(RoundEnvironment env, Map<String, JsonObjectHolder> jsonObjectMap, Elements elements, Types types) {
+    public void findAndParseObjects(RoundEnvironment env, Map<String, JsonObjectHolder> jsonObjectMap, Map<String, JsonEnumHolder> jsonEnumMap, Elements elements, Types types) {
         for (Element element : env.getElementsAnnotatedWith(JsonObject.class)) {
             try {
                 processJsonObjectAnnotation(element, jsonObjectMap, elements, types);

--- a/processor/src/main/java/com/bluelinelabs/logansquare/processor/processor/OnJsonParseCompleteProcessor.java
+++ b/processor/src/main/java/com/bluelinelabs/logansquare/processor/processor/OnJsonParseCompleteProcessor.java
@@ -1,8 +1,13 @@
 package com.bluelinelabs.logansquare.processor.processor;
 
 import com.bluelinelabs.logansquare.annotation.OnJsonParseComplete;
+import com.bluelinelabs.logansquare.processor.JsonEnumHolder;
 import com.bluelinelabs.logansquare.processor.JsonObjectHolder;
 import com.bluelinelabs.logansquare.processor.TypeUtils;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.Map;
 
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.annotation.processing.RoundEnvironment;
@@ -11,9 +16,6 @@ import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.util.Elements;
 import javax.lang.model.util.Types;
-import java.io.PrintWriter;
-import java.io.StringWriter;
-import java.util.Map;
 
 public class OnJsonParseCompleteProcessor extends MethodProcessor {
 
@@ -27,7 +29,7 @@ public class OnJsonParseCompleteProcessor extends MethodProcessor {
     }
 
     @Override
-    public void findAndParseObjects(RoundEnvironment env, Map<String, JsonObjectHolder> jsonObjectMap, Elements elements, Types types) {
+    public void findAndParseObjects(RoundEnvironment env, Map<String, JsonObjectHolder> jsonObjectMap, Map<String, JsonEnumHolder> jsonEnumMap, Elements elements, Types types) {
         for (Element element : env.getElementsAnnotatedWith(OnJsonParseComplete.class)) {
             try {
                 processOnCompleteMethodAnnotation(element, jsonObjectMap, elements);

--- a/processor/src/main/java/com/bluelinelabs/logansquare/processor/processor/OnPreSerializeProcessor.java
+++ b/processor/src/main/java/com/bluelinelabs/logansquare/processor/processor/OnPreSerializeProcessor.java
@@ -1,8 +1,13 @@
 package com.bluelinelabs.logansquare.processor.processor;
 
 import com.bluelinelabs.logansquare.annotation.OnPreJsonSerialize;
+import com.bluelinelabs.logansquare.processor.JsonEnumHolder;
 import com.bluelinelabs.logansquare.processor.JsonObjectHolder;
 import com.bluelinelabs.logansquare.processor.TypeUtils;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.Map;
 
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.annotation.processing.RoundEnvironment;
@@ -11,9 +16,6 @@ import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.util.Elements;
 import javax.lang.model.util.Types;
-import java.io.PrintWriter;
-import java.io.StringWriter;
-import java.util.Map;
 
 public class OnPreSerializeProcessor extends MethodProcessor {
 
@@ -27,7 +29,7 @@ public class OnPreSerializeProcessor extends MethodProcessor {
     }
 
     @Override
-    public void findAndParseObjects(RoundEnvironment env, Map<String, JsonObjectHolder> jsonObjectMap, Elements elements, Types types) {
+    public void findAndParseObjects(RoundEnvironment env, Map<String, JsonObjectHolder> jsonObjectMap, Map<String, JsonEnumHolder> jsonEnumMap, Elements elements, Types types) {
         for (Element element : env.getElementsAnnotatedWith(OnPreJsonSerialize.class)) {
             try {
                 processOnPreJsonSerializeMethodAnnotation(element, jsonObjectMap, elements);

--- a/processor/src/main/java/com/bluelinelabs/logansquare/processor/processor/Processor.java
+++ b/processor/src/main/java/com/bluelinelabs/logansquare/processor/processor/Processor.java
@@ -1,15 +1,17 @@
 package com.bluelinelabs.logansquare.processor.processor;
 
+import com.bluelinelabs.logansquare.processor.JsonEnumHolder;
 import com.bluelinelabs.logansquare.processor.JsonObjectHolder;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.annotation.processing.RoundEnvironment;
 import javax.lang.model.element.Element;
 import javax.lang.model.util.Elements;
 import javax.lang.model.util.Types;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
 
 import static javax.tools.Diagnostic.Kind.ERROR;
 
@@ -22,10 +24,11 @@ public abstract class Processor {
     }
 
     public abstract Class getAnnotation();
-    public abstract void findAndParseObjects(RoundEnvironment env, Map<String, JsonObjectHolder> jsonObjectMap, Elements elements, Types types);
+    public abstract void findAndParseObjects(RoundEnvironment env, Map<String, JsonObjectHolder> jsonObjectMap, Map<String, JsonEnumHolder> jsonEnumMap, Elements elements, Types types);
 
     public static List<Processor> allProcessors(ProcessingEnvironment processingEnvironment) {
         List<Processor> list = new ArrayList<>();
+        list.add(new JsonEnumProcessor(processingEnvironment));
         list.add(new JsonObjectProcessor(processingEnvironment));
         list.add(new OnJsonParseCompleteProcessor(processingEnvironment));
         list.add(new OnPreSerializeProcessor(processingEnvironment));

--- a/processor/src/main/java/com/bluelinelabs/logansquare/processor/processor/Processor.java
+++ b/processor/src/main/java/com/bluelinelabs/logansquare/processor/processor/Processor.java
@@ -1,5 +1,9 @@
 package com.bluelinelabs.logansquare.processor.processor;
 
+import com.bluelinelabs.logansquare.annotation.JsonBooleanValue;
+import com.bluelinelabs.logansquare.annotation.JsonNullValue;
+import com.bluelinelabs.logansquare.annotation.JsonNumberValue;
+import com.bluelinelabs.logansquare.annotation.JsonStringValue;
 import com.bluelinelabs.logansquare.processor.JsonEnumHolder;
 import com.bluelinelabs.logansquare.processor.JsonObjectHolder;
 
@@ -28,11 +32,18 @@ public abstract class Processor {
 
     public static List<Processor> allProcessors(ProcessingEnvironment processingEnvironment) {
         List<Processor> list = new ArrayList<>();
+
         list.add(new JsonEnumProcessor(processingEnvironment));
+        list.add(new JsonEnumValueProcessor<>(JsonStringValue.class, processingEnvironment));
+        list.add(new JsonEnumValueProcessor<>(JsonNumberValue.class, processingEnvironment));
+        list.add(new JsonEnumValueProcessor<>(JsonBooleanValue.class, processingEnvironment));
+        list.add(new JsonEnumValueProcessor<>(JsonNullValue.class, processingEnvironment));
+
         list.add(new JsonObjectProcessor(processingEnvironment));
         list.add(new OnJsonParseCompleteProcessor(processingEnvironment));
         list.add(new OnPreSerializeProcessor(processingEnvironment));
         list.add(new JsonFieldProcessor(processingEnvironment));
+
         return list;
     }
 

--- a/processor/src/main/java/com/bluelinelabs/logansquare/processor/type/Type.java
+++ b/processor/src/main/java/com/bluelinelabs/logansquare/processor/type/Type.java
@@ -78,6 +78,10 @@ public abstract class Type {
         }
     }
 
+    public void addParameterType(Type type) {
+        parameterTypes.add(type);
+    }
+
     public void addParameterType(TypeMirror parameterType, Elements elements, Types types) {
         parameterTypes.add(Type.typeFor(parameterType, null, elements, types));
     }

--- a/processor/src/main/java/com/bluelinelabs/logansquare/processor/type/collection/ArrayCollectionType.java
+++ b/processor/src/main/java/com/bluelinelabs/logansquare/processor/type/collection/ArrayCollectionType.java
@@ -21,6 +21,7 @@ public class ArrayCollectionType extends CollectionType {
 
     public ArrayCollectionType(Type arrayType) {
         this.arrayType = arrayType;
+        addParameterType(arrayType);
     }
 
     @Override

--- a/processor/src/main/java/com/bluelinelabs/logansquare/processor/type/collection/ArrayCollectionType.java
+++ b/processor/src/main/java/com/bluelinelabs/logansquare/processor/type/collection/ArrayCollectionType.java
@@ -132,8 +132,18 @@ public class ArrayCollectionType extends CollectionType {
 
         builder
                 .endControlFlow()
-                .addStatement("$L.writeEndArray()", JSON_GENERATOR_VARIABLE_NAME)
-                .endControlFlow();
+                .addStatement("$L.writeEndArray()", JSON_GENERATOR_VARIABLE_NAME);
+
+        if (writeIfNull) {
+            builder.nextControlFlow("else");
+
+            if (isObjectProperty) {
+                builder.addStatement("$L.writeFieldName($S)", JSON_GENERATOR_VARIABLE_NAME, fieldName);
+            }
+            builder.addStatement("$L.writeNull()", JSON_GENERATOR_VARIABLE_NAME);
+        }
+
+        builder.endControlFlow();
     }
 
     @Override

--- a/processor/src/main/java/com/bluelinelabs/logansquare/processor/type/collection/MapCollectionType.java
+++ b/processor/src/main/java/com/bluelinelabs/logansquare/processor/type/collection/MapCollectionType.java
@@ -99,7 +99,17 @@ public abstract class MapCollectionType extends CollectionType {
         builder
                 .endControlFlow()
                 .endControlFlow()
-                .addStatement("$L.writeEndObject()", JSON_GENERATOR_VARIABLE_NAME)
-                .endControlFlow();
+                .addStatement("$L.writeEndObject()", JSON_GENERATOR_VARIABLE_NAME);
+
+        if (writeIfNull) {
+            builder.nextControlFlow("else");
+
+            if (isObjectProperty) {
+                builder.addStatement("$L.writeFieldName($S)", JSON_GENERATOR_VARIABLE_NAME, fieldName);
+            }
+            builder.addStatement("$L.writeNull()", JSON_GENERATOR_VARIABLE_NAME);
+        }
+
+        builder.endControlFlow();
     }
 }

--- a/processor/src/main/java/com/bluelinelabs/logansquare/processor/type/collection/SingleParameterCollectionType.java
+++ b/processor/src/main/java/com/bluelinelabs/logansquare/processor/type/collection/SingleParameterCollectionType.java
@@ -7,7 +7,6 @@ import com.squareup.javapoet.MethodSpec;
 import com.squareup.javapoet.MethodSpec.Builder;
 
 import java.util.List;
-import java.util.Set;
 
 import static com.bluelinelabs.logansquare.processor.ObjectMapperInjector.JSON_GENERATOR_VARIABLE_NAME;
 import static com.bluelinelabs.logansquare.processor.ObjectMapperInjector.JSON_PARSER_VARIABLE_NAME;
@@ -78,11 +77,21 @@ public abstract class SingleParameterCollectionType extends CollectionType {
                     .addStatement("$L.writeNull()", JSON_GENERATOR_VARIABLE_NAME);
         }
 
-            builder
+        builder
                 .endControlFlow()
                 .endControlFlow()
-                .addStatement("$L.writeEndArray()", JSON_GENERATOR_VARIABLE_NAME)
-                .endControlFlow();
+                .addStatement("$L.writeEndArray()", JSON_GENERATOR_VARIABLE_NAME);
+
+        if (writeIfNull) {
+            builder.nextControlFlow("else");
+
+            if (isObjectProperty) {
+                builder.addStatement("$L.writeFieldName($S)", JSON_GENERATOR_VARIABLE_NAME, fieldName);
+            }
+            builder.addStatement("$L.writeNull()", JSON_GENERATOR_VARIABLE_NAME);
+        }
+
+        builder.endControlFlow();
     }
 
 }

--- a/processor/src/main/java/com/bluelinelabs/logansquare/processor/type/field/DynamicFieldType.java
+++ b/processor/src/main/java/com/bluelinelabs/logansquare/processor/type/field/DynamicFieldType.java
@@ -1,6 +1,6 @@
 package com.bluelinelabs.logansquare.processor.type.field;
 
-import com.bluelinelabs.logansquare.LoganSquare;
+import com.bluelinelabs.logansquare.processor.ObjectMapperInjector;
 import com.squareup.javapoet.MethodSpec.Builder;
 import com.squareup.javapoet.TypeName;
 
@@ -30,8 +30,8 @@ public class DynamicFieldType extends FieldType {
 
     @Override
     public void parse(Builder builder, int depth, String setter, Object... setterFormatArgs) {
-        setter = replaceLastLiteral(setter, "$T.typeConverterFor($T.class).parse($L)");
-        builder.addStatement(setter, expandStringArgs(setterFormatArgs, LoganSquare.class, mTypeName, JSON_PARSER_VARIABLE_NAME));
+        setter = replaceLastLiteral(setter, ObjectMapperInjector.getTypeConverterGetter(mTypeName) + "().parse($L)");
+        builder.addStatement(setter, expandStringArgs(setterFormatArgs, JSON_PARSER_VARIABLE_NAME));
     }
 
     @Override
@@ -40,9 +40,7 @@ public class DynamicFieldType extends FieldType {
             builder.beginControlFlow("if ($L != null)", getter);
         }
 
-        builder.addStatement("$T.typeConverterFor($T.class).serialize($L, $S, $L, $L)", LoganSquare.class, mTypeName, getter, isObjectProperty
-                ? fieldName : null, isObjectProperty, JSON_GENERATOR_VARIABLE_NAME);
-
+        builder.addStatement(ObjectMapperInjector.getTypeConverterGetter(mTypeName) + "().serialize($L, $S, $L, $L)", getter, isObjectProperty ? fieldName : null, isObjectProperty, JSON_GENERATOR_VARIABLE_NAME);
         if (!mTypeName.isPrimitive() && checkIfNull) {
             if (writeIfNull) {
                 builder.nextControlFlow("else");

--- a/processor/src/main/java/com/bluelinelabs/logansquare/processor/type/field/DynamicFieldType.java
+++ b/processor/src/main/java/com/bluelinelabs/logansquare/processor/type/field/DynamicFieldType.java
@@ -1,6 +1,7 @@
 package com.bluelinelabs.logansquare.processor.type.field;
 
 import com.bluelinelabs.logansquare.LoganSquare;
+import com.bluelinelabs.logansquare.processor.ObjectMapperInjector;
 import com.squareup.javapoet.MethodSpec.Builder;
 import com.squareup.javapoet.TypeName;
 
@@ -40,7 +41,7 @@ public class DynamicFieldType extends FieldType {
             builder.beginControlFlow("if ($L != null)", getter);
         }
 
-        builder.addStatement("$T.typeConverterFor($T.class).serialize($L, $S, $L, $L)", LoganSquare.class, mTypeName, getter, isObjectProperty
+        builder.addStatement("$L().serialize($L, $S, $L, $L)", ObjectMapperInjector.getTypeConverterGetter(mTypeName), getter, isObjectProperty
                 ? fieldName : null, isObjectProperty, JSON_GENERATOR_VARIABLE_NAME);
 
         if (!mTypeName.isPrimitive() && checkIfNull) {

--- a/processor/src/test/java/com/bluelinelabs/logansquare/processor/AnnotatedEnumTest.java
+++ b/processor/src/test/java/com/bluelinelabs/logansquare/processor/AnnotatedEnumTest.java
@@ -1,0 +1,72 @@
+package com.bluelinelabs.logansquare.processor;
+
+import com.google.testing.compile.JavaFileObjects;
+
+import org.junit.Test;
+
+import static com.google.common.truth.Truth.ASSERT;
+import static com.google.testing.compile.JavaSourceSubjectFactory.javaSource;
+
+public class AnnotatedEnumTest {
+
+    @Test
+    public void generatedBooleanEnumSource() {
+        ASSERT.about(javaSource())
+                .that(JavaFileObjects.forResource("model/good/BooleanEnum.java"))
+                .processedWith(new JsonAnnotationProcessor())
+                .compilesWithoutError()
+                .and()
+                .generatesSources(JavaFileObjects.forResource("generated/BooleanEnum$$JsonTypeConverter.java"));
+    }
+
+    @Test
+    public void generatedNumberEnumSource() {
+        ASSERT.about(javaSource())
+                .that(JavaFileObjects.forResource("model/good/NumberEnum.java"))
+                .processedWith(new JsonAnnotationProcessor())
+                .compilesWithoutError()
+                .and()
+                .generatesSources(JavaFileObjects.forResource("generated/NumberEnum$$JsonTypeConverter.java"));
+    }
+
+    @Test
+    public void generatedStringEnumSource() {
+        ASSERT.about(javaSource())
+                .that(JavaFileObjects.forResource("model/good/StringEnum.java"))
+                .processedWith(new JsonAnnotationProcessor())
+                .compilesWithoutError()
+                .and()
+                .generatesSources(JavaFileObjects.forResource("generated/StringEnum$$JsonTypeConverter.java"));
+    }
+
+    @Test
+    public void generatedNullableEnumSource() {
+        ASSERT.about(javaSource())
+                .that(JavaFileObjects.forResource("model/good/NullableEnum.java"))
+                .processedWith(new JsonAnnotationProcessor())
+                .compilesWithoutError()
+                .and()
+                .generatesSources(JavaFileObjects.forResource("generated/NullableEnum$$JsonTypeConverter.java"));
+    }
+
+    @Test
+    public void generatedLowerCaseNamingPolicyEnumSource() {
+        ASSERT.about(javaSource())
+                .that(JavaFileObjects.forResource("model/good/LowerCaseNamingPolicyEnum.java"))
+                .processedWith(new JsonAnnotationProcessor())
+                .compilesWithoutError()
+                .and()
+                .generatesSources(JavaFileObjects.forResource("generated/LowerCaseNamingPolicyEnum$$JsonTypeConverter.java"));
+    }
+
+    @Test
+    public void generatedDefaultNamingPolicyEnumSource() {
+        ASSERT.about(javaSource())
+                .that(JavaFileObjects.forResource("model/good/DefaultNamingPolicyEnum.java"))
+                .processedWith(new JsonAnnotationProcessor())
+                .compilesWithoutError()
+                .and()
+                .generatesSources(JavaFileObjects.forResource("generated/DefaultNamingPolicyEnum$$JsonTypeConverter.java"));
+    }
+
+}

--- a/processor/src/test/java/com/bluelinelabs/logansquare/processor/RoundTripTests.java
+++ b/processor/src/test/java/com/bluelinelabs/logansquare/processor/RoundTripTests.java
@@ -2,6 +2,7 @@ package com.bluelinelabs.logansquare.processor;
 
 import com.bluelinelabs.logansquare.LoganSquare;
 import com.bluelinelabs.logansquare.ParameterizedType;
+import com.bluelinelabs.logansquare.processor.model.AnnotatedEnumModel;
 import com.bluelinelabs.logansquare.processor.model.EnumListModel;
 import com.bluelinelabs.logansquare.processor.model.EnumListModel.LsEnumTestConverter;
 import com.bluelinelabs.logansquare.processor.model.EnumListModel.TestEnum;
@@ -291,6 +292,19 @@ public class RoundTripTests {
         try {
             LoganSquare.registerTypeConverter(TestEnum.class, new LsEnumTestConverter());
             EnumListModel test = LoganSquare.parse(json, EnumListModel.class);
+            serialized = LoganSquare.serialize(test);
+        } catch (Exception ignored) { }
+
+        ASSERT.that(json.equals(serialized)).isTrue();
+    }
+
+    @Test
+    public void annotatedEnum() {
+        String json = "{\"boolean_enum\":false,\"default_naming_policy_enum\":\"ONE\",\"lower_case_naming_policy_enum\":\"one\",\"nullable_enum\":null,\"number_enum\":1,\"string_enum\":\"one\"}";
+
+        String serialized = null;
+        try {
+            AnnotatedEnumModel test = LoganSquare.parse(json, AnnotatedEnumModel.class);
             serialized = LoganSquare.serialize(test);
         } catch (Exception ignored) { }
 

--- a/processor/src/test/java/com/bluelinelabs/logansquare/processor/model/AnnotatedEnumModel.java
+++ b/processor/src/test/java/com/bluelinelabs/logansquare/processor/model/AnnotatedEnumModel.java
@@ -1,0 +1,71 @@
+package com.bluelinelabs.logansquare.processor.model;
+
+import com.bluelinelabs.logansquare.annotation.JsonBooleanValue;
+import com.bluelinelabs.logansquare.annotation.JsonEnum;
+import com.bluelinelabs.logansquare.annotation.JsonField;
+import com.bluelinelabs.logansquare.annotation.JsonNullValue;
+import com.bluelinelabs.logansquare.annotation.JsonNumberValue;
+import com.bluelinelabs.logansquare.annotation.JsonObject;
+import com.bluelinelabs.logansquare.annotation.JsonStringValue;
+
+@JsonObject
+public class AnnotatedEnumModel {
+
+    @JsonField(name = "default_naming_policy_enum")
+    public DefaultNamingPolicyEnum defaultNamingPolicyEnum;
+    @JsonField(name = "lower_case_naming_policy_enum")
+    public LowerCaseNamingPolicyEnum lowerCaseNamingPolicyEnum;
+    @JsonField(name = "string_enum")
+    public StringEnum stringEnum;
+    @JsonField(name = "number_enum")
+    public NumberEnum numberEnum;
+    @JsonField(name = "boolean_enum")
+    public BooleanEnum booleanEnum;
+    @JsonField(name = "nullable_enum")
+    public NullableEnum nullableEnum;
+    
+    @JsonEnum
+    public enum DefaultNamingPolicyEnum {
+        ONE,
+        TWO
+    }
+
+    @JsonEnum(valueNamingPolicy = JsonEnum.ValueNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
+    public enum LowerCaseNamingPolicyEnum {
+        ONE,
+        TWO
+    }
+
+    @JsonEnum
+    public enum StringEnum {
+        @JsonStringValue("one")
+        ONE,
+        @JsonStringValue("two")
+        TWO
+    }
+
+    @JsonEnum
+    public enum NumberEnum {
+        @JsonNumberValue(1)
+        ONE,
+        @JsonNumberValue(2)
+        TWO
+    }
+
+    @JsonEnum
+    public enum BooleanEnum {
+        @JsonBooleanValue(true)
+        TRUE,
+        @JsonBooleanValue(false)
+        FALSE
+    }
+
+    @JsonEnum
+    public enum NullableEnum {
+        ONE,
+        TWO,
+        @JsonNullValue
+        NULL
+    }
+
+}

--- a/processor/src/test/resources/generated/BooleanEnum$$JsonTypeConverter.java
+++ b/processor/src/test/resources/generated/BooleanEnum$$JsonTypeConverter.java
@@ -1,0 +1,62 @@
+package com.bluelinelabs.logansquare.processor;
+
+import com.bluelinelabs.logansquare.typeconverters.TypeConverter;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import java.io.IOException;
+import java.lang.Override;
+import java.lang.String;
+
+public final class BooleanEnum$$JsonTypeConverter implements TypeConverter<BooleanEnum> {
+    @Override
+    public BooleanEnum parse(JsonParser jsonParser) throws IOException {
+        if (jsonParser.getCurrentToken() == JsonToken.VALUE_NULL) {
+            return null;
+        }
+        boolean parsedValue = jsonParser.getValueAsBoolean();
+        if(parsedValue == true) {
+            return BooleanEnum.TRUE;
+        } else if(parsedValue == false) {
+            return BooleanEnum.FALSE;
+        }
+        throw new IllegalArgumentException(jsonParser.toString());
+    }
+
+    @Override
+    public void serialize(BooleanEnum value, String fieldName, boolean writeFieldNameForObject, JsonGenerator jsonGenerator) throws IOException {
+        if (fieldName != null) {
+            if (value == null) {
+                jsonGenerator.writeNullField(fieldName);
+                return;
+            }
+            switch (value) {
+                case TRUE: {
+                    jsonGenerator.writeBooleanField(fieldName, true);
+                    break;
+                }
+                case FALSE: {
+                    jsonGenerator.writeBooleanField(fieldName, false);
+                    break;
+                }
+                default: throw new IllegalArgumentException(value.name());
+            }
+        } else {
+            if (value == null) {
+                jsonGenerator.writeNull();
+                return;
+            }
+            switch (value) {
+                case TRUE: {
+                    jsonGenerator.writeBoolean(true);
+                    break;
+                }
+                case FALSE: {
+                    jsonGenerator.writeBoolean(false);
+                    break;
+                }
+                default: throw new IllegalArgumentException(value.name());
+            }
+        }
+    }
+}

--- a/processor/src/test/resources/generated/DefaultNamingPolicyEnum$$JsonTypeConverter.java
+++ b/processor/src/test/resources/generated/DefaultNamingPolicyEnum$$JsonTypeConverter.java
@@ -1,0 +1,62 @@
+package com.bluelinelabs.logansquare.processor;
+
+import com.bluelinelabs.logansquare.typeconverters.TypeConverter;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import java.io.IOException;
+import java.lang.Override;
+import java.lang.String;
+
+public final class DefaultNamingPolicyEnum$$JsonTypeConverter implements TypeConverter<DefaultNamingPolicyEnum> {
+    @Override
+    public DefaultNamingPolicyEnum parse(JsonParser jsonParser) throws IOException {
+        if (jsonParser.getCurrentToken() == JsonToken.VALUE_NULL) {
+            return null;
+        }
+        String parsedValue = jsonParser.getValueAsString();
+        if(parsedValue.equals("ONE")) {
+            return DefaultNamingPolicyEnum.ONE;
+        } else if(parsedValue.equals("TWO")) {
+            return DefaultNamingPolicyEnum.TWO;
+        }
+        throw new IllegalArgumentException(jsonParser.toString());
+    }
+
+    @Override
+    public void serialize(DefaultNamingPolicyEnum value, String fieldName, boolean writeFieldNameForObject, JsonGenerator jsonGenerator) throws IOException {
+        if (fieldName != null) {
+            if (value == null) {
+                jsonGenerator.writeNullField(fieldName);
+                return;
+            }
+            switch (value) {
+                case ONE: {
+                    jsonGenerator.writeStringField(fieldName, "ONE");
+                    break;
+                }
+                case TWO: {
+                    jsonGenerator.writeStringField(fieldName, "TWO");
+                    break;
+                }
+                default: throw new IllegalArgumentException(value.name());
+            }
+        } else {
+            if (value == null) {
+                jsonGenerator.writeNull();
+                return;
+            }
+            switch (value) {
+                case ONE: {
+                    jsonGenerator.writeString("ONE");
+                    break;
+                }
+                case TWO: {
+                    jsonGenerator.writeString("TWO");
+                    break;
+                }
+                default: throw new IllegalArgumentException(value.name());
+            }
+        }
+    }
+}

--- a/processor/src/test/resources/generated/LowerCaseNamingPolicyEnum$$JsonTypeConverter.java
+++ b/processor/src/test/resources/generated/LowerCaseNamingPolicyEnum$$JsonTypeConverter.java
@@ -1,0 +1,62 @@
+package com.bluelinelabs.logansquare.processor;
+
+import com.bluelinelabs.logansquare.typeconverters.TypeConverter;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import java.io.IOException;
+import java.lang.Override;
+import java.lang.String;
+
+public final class LowerCaseNamingPolicyEnum$$JsonTypeConverter implements TypeConverter<LowerCaseNamingPolicyEnum> {
+    @Override
+    public LowerCaseNamingPolicyEnum parse(JsonParser jsonParser) throws IOException {
+        if (jsonParser.getCurrentToken() == JsonToken.VALUE_NULL) {
+            return null;
+        }
+        String parsedValue = jsonParser.getValueAsString();
+        if(parsedValue.equals("one")) {
+            return LowerCaseNamingPolicyEnum.ONE;
+        } else if(parsedValue.equals("two")) {
+            return LowerCaseNamingPolicyEnum.TWO;
+        }
+        throw new IllegalArgumentException(jsonParser.toString());
+    }
+
+    @Override
+    public void serialize(LowerCaseNamingPolicyEnum value, String fieldName, boolean writeFieldNameForObject, JsonGenerator jsonGenerator) throws IOException {
+        if (fieldName != null) {
+            if (value == null) {
+                jsonGenerator.writeNullField(fieldName);
+                return;
+            }
+            switch (value) {
+                case ONE: {
+                    jsonGenerator.writeStringField(fieldName, "one");
+                    break;
+                }
+                case TWO: {
+                    jsonGenerator.writeStringField(fieldName, "two");
+                    break;
+                }
+                default: throw new IllegalArgumentException(value.name());
+            }
+        } else {
+            if (value == null) {
+                jsonGenerator.writeNull();
+                return;
+            }
+            switch (value) {
+                case ONE: {
+                    jsonGenerator.writeString("one");
+                    break;
+                }
+                case TWO: {
+                    jsonGenerator.writeString("two");
+                    break;
+                }
+                default: throw new IllegalArgumentException(value.name());
+            }
+        }
+    }
+}

--- a/processor/src/test/resources/generated/NullableEnum$$JsonTypeConverter.java
+++ b/processor/src/test/resources/generated/NullableEnum$$JsonTypeConverter.java
@@ -1,0 +1,62 @@
+package com.bluelinelabs.logansquare.processor;
+
+import com.bluelinelabs.logansquare.typeconverters.TypeConverter;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import java.io.IOException;
+import java.lang.Override;
+import java.lang.String;
+
+public final class NullableEnum$$JsonTypeConverter implements TypeConverter<NullableEnum> {
+    @Override
+    public NullableEnum parse(JsonParser jsonParser) throws IOException {
+        if (jsonParser.getCurrentToken() == JsonToken.VALUE_NULL) {
+            return NullableEnum.NULL;
+        }
+        String parsedValue = jsonParser.getValueAsString();
+        if(parsedValue.equals("ONE")) {
+            return NullableEnum.ONE;
+        } else if(parsedValue.equals("TWO")) {
+            return NullableEnum.TWO;
+        }
+        throw new IllegalArgumentException(jsonParser.toString());
+    }
+
+    @Override
+    public void serialize(NullableEnum value, String fieldName, boolean writeFieldNameForObject, JsonGenerator jsonGenerator) throws IOException {
+        if (fieldName != null) {
+            if (value == null || value == NullableEnum.NULL) {
+                jsonGenerator.writeNullField(fieldName);
+                return;
+            }
+            switch (value) {
+                case ONE: {
+                    jsonGenerator.writeStringField(fieldName, "ONE");
+                    break;
+                }
+                case TWO: {
+                    jsonGenerator.writeStringField(fieldName, "TWO");
+                    break;
+                }
+                default: throw new IllegalArgumentException(value.name());
+            }
+        } else {
+            if (value == null || value == NullableEnum.NULL) {
+                jsonGenerator.writeNull();
+                return;
+            }
+            switch (value) {
+                case ONE: {
+                    jsonGenerator.writeString("ONE");
+                    break;
+                }
+                case TWO: {
+                    jsonGenerator.writeString("TWO");
+                    break;
+                }
+                default: throw new IllegalArgumentException(value.name());
+            }
+        }
+    }
+}

--- a/processor/src/test/resources/generated/NumberEnum$$JsonTypeConverter.java
+++ b/processor/src/test/resources/generated/NumberEnum$$JsonTypeConverter.java
@@ -1,0 +1,62 @@
+package com.bluelinelabs.logansquare.processor;
+
+import com.bluelinelabs.logansquare.typeconverters.TypeConverter;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import java.io.IOException;
+import java.lang.Override;
+import java.lang.String;
+
+public final class NumberEnum$$JsonTypeConverter implements TypeConverter<NumberEnum> {
+    @Override
+    public NumberEnum parse(JsonParser jsonParser) throws IOException {
+        if (jsonParser.getCurrentToken() == JsonToken.VALUE_NULL) {
+            return null;
+        }
+        long parsedValue = jsonParser.getValueAsLong();
+        if(parsedValue == 1L) {
+            return NumberEnum.ONE;
+        } else if(parsedValue == 2L) {
+            return NumberEnum.TWO;
+        }
+        throw new IllegalArgumentException(jsonParser.toString());
+    }
+
+    @Override
+    public void serialize(NumberEnum value, String fieldName, boolean writeFieldNameForObject, JsonGenerator jsonGenerator) throws IOException {
+        if (fieldName != null) {
+            if (value == null) {
+                jsonGenerator.writeNullField(fieldName);
+                return;
+            }
+            switch (value) {
+                case ONE: {
+                    jsonGenerator.writeNumberField(fieldName, 1L);
+                    break;
+                }
+                case TWO: {
+                    jsonGenerator.writeNumberField(fieldName, 2L);
+                    break;
+                }
+                default: throw new IllegalArgumentException(value.name());
+            }
+        } else {
+            if (value == null) {
+                jsonGenerator.writeNull();
+                return;
+            }
+            switch (value) {
+                case ONE: {
+                    jsonGenerator.writeNumber(1L);
+                    break;
+                }
+                case TWO: {
+                    jsonGenerator.writeNumber(2L);
+                    break;
+                }
+                default: throw new IllegalArgumentException(value.name());
+            }
+        }
+    }
+}

--- a/processor/src/test/resources/generated/StringEnum$$JsonTypeConverter.java
+++ b/processor/src/test/resources/generated/StringEnum$$JsonTypeConverter.java
@@ -1,0 +1,62 @@
+package com.bluelinelabs.logansquare.processor;
+
+import com.bluelinelabs.logansquare.typeconverters.TypeConverter;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import java.io.IOException;
+import java.lang.Override;
+import java.lang.String;
+
+public final class StringEnum$$JsonTypeConverter implements TypeConverter<StringEnum> {
+    @Override
+    public StringEnum parse(JsonParser jsonParser) throws IOException {
+        if (jsonParser.getCurrentToken() == JsonToken.VALUE_NULL) {
+            return null;
+        }
+        String parsedValue = jsonParser.getValueAsString();
+        if(parsedValue.equals("one")) {
+            return StringEnum.ONE;
+        } else if(parsedValue.equals("two")) {
+            return StringEnum.TWO;
+        }
+        throw new IllegalArgumentException(jsonParser.toString());
+    }
+
+    @Override
+    public void serialize(StringEnum value, String fieldName, boolean writeFieldNameForObject, JsonGenerator jsonGenerator) throws IOException {
+        if (fieldName != null) {
+            if (value == null) {
+                jsonGenerator.writeNullField(fieldName);
+                return;
+            }
+            switch (value) {
+                case ONE: {
+                    jsonGenerator.writeStringField(fieldName, "one");
+                    break;
+                }
+                case TWO: {
+                    jsonGenerator.writeStringField(fieldName, "two");
+                    break;
+                }
+                default: throw new IllegalArgumentException(value.name());
+            }
+        } else {
+            if (value == null) {
+                jsonGenerator.writeNull();
+                return;
+            }
+            switch (value) {
+                case ONE: {
+                    jsonGenerator.writeString("one");
+                    break;
+                }
+                case TWO: {
+                    jsonGenerator.writeString("two");
+                    break;
+                }
+                default: throw new IllegalArgumentException(value.name());
+            }
+        }
+    }
+}

--- a/processor/src/test/resources/model/good/BooleanEnum.java
+++ b/processor/src/test/resources/model/good/BooleanEnum.java
@@ -1,0 +1,12 @@
+package com.bluelinelabs.logansquare.processor;
+
+import com.bluelinelabs.logansquare.annotation.JsonEnum;
+import com.bluelinelabs.logansquare.annotation.JsonBooleanValue;
+
+@JsonEnum
+public enum BooleanEnum {
+    @JsonBooleanValue(true)
+    TRUE,
+    @JsonBooleanValue(false)
+    FALSE
+}

--- a/processor/src/test/resources/model/good/DefaultNamingPolicyEnum.java
+++ b/processor/src/test/resources/model/good/DefaultNamingPolicyEnum.java
@@ -1,0 +1,9 @@
+package com.bluelinelabs.logansquare.processor;
+
+import com.bluelinelabs.logansquare.annotation.JsonEnum;
+
+@JsonEnum
+public enum DefaultNamingPolicyEnum {
+    ONE,
+    TWO
+}

--- a/processor/src/test/resources/model/good/LowerCaseNamingPolicyEnum.java
+++ b/processor/src/test/resources/model/good/LowerCaseNamingPolicyEnum.java
@@ -1,0 +1,9 @@
+package com.bluelinelabs.logansquare.processor;
+
+import com.bluelinelabs.logansquare.annotation.JsonEnum;
+
+@JsonEnum(valueNamingPolicy = JsonEnum.ValueNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
+public enum LowerCaseNamingPolicyEnum {
+    ONE,
+    TWO
+}

--- a/processor/src/test/resources/model/good/NullableEnum.java
+++ b/processor/src/test/resources/model/good/NullableEnum.java
@@ -1,0 +1,12 @@
+package com.bluelinelabs.logansquare.processor;
+
+import com.bluelinelabs.logansquare.annotation.JsonEnum;
+import com.bluelinelabs.logansquare.annotation.JsonNullValue;
+
+@JsonEnum
+public enum NullableEnum {
+    ONE,
+    TWO,
+    @JsonNullValue
+    NULL
+}

--- a/processor/src/test/resources/model/good/NumberEnum.java
+++ b/processor/src/test/resources/model/good/NumberEnum.java
@@ -1,0 +1,12 @@
+package com.bluelinelabs.logansquare.processor;
+
+import com.bluelinelabs.logansquare.annotation.JsonEnum;
+import com.bluelinelabs.logansquare.annotation.JsonNumberValue;
+
+@JsonEnum
+public enum NumberEnum {
+    @JsonNumberValue(1)
+    ONE,
+    @JsonNumberValue(2)
+    TWO
+}

--- a/processor/src/test/resources/model/good/StringEnum.java
+++ b/processor/src/test/resources/model/good/StringEnum.java
@@ -1,0 +1,12 @@
+package com.bluelinelabs.logansquare.processor;
+
+import com.bluelinelabs.logansquare.annotation.JsonEnum;
+import com.bluelinelabs.logansquare.annotation.JsonStringValue;
+
+@JsonEnum
+public enum StringEnum {
+    @JsonStringValue("one")
+    ONE,
+    @JsonStringValue("two")
+    TWO
+}


### PR DESCRIPTION
With that PR it is possible to let processor generate code for enum parsing.

It will create type converter (same way like mappers) named with suffix $$JsonTypeConverter.
For enums parser will firstly check if such converter added in `LoganSquare.ENUM_CONVERTERS` map then if class `Class.forName(enumClass.getName() + Constants.CONVERTER_CLASS_SUFFIX)` exists. Similar to mappers logic.

To create enum model yo need to write something like
```java
@JsonEnum
enum MyEnum {
  @JsonStringValue
  TYPE_ONE,
  @JsonStringValue
  TYPE_TWO
}
```
No specific code to use such enum model:
```java
@JsonObject
class MyClass {
 @JsonField
 public MyEnum enumField;
}
```
By default it is associating name of enum value with string value coming from JSON. But it is possible to specify ValueNamingPolicy in `@JsonEnum` annotation.

Also it is possible to specify concrete string/boolean/number associated with enum value:
```java
@JsonEnum
enum MyStringEnum {
  @JsonStringValue("type_one")
  TYPE_ONE
}
```
```java
@JsonEnum
enum MyNumberEnum {
  @JsonNumberValue(1)
  MALE,
  @JsonNumberValue(0)
  FEMALE
}
```
```java
@JsonEnum
enum MyNumberEnum {
  @JsonBooleanValue(true)
  MALE,
  @JsonBooleanValue(false)
  FEMALE
}
```

More than that it is also possible to specify null associated with enum value - it means, if null have came from server then it will be specific enum value in field on parsing. And on serialization if it will be such value in field so client will send null to server.
```java
@JsonEnum
enum MyStringrEnum {
  @JsonStringValue("value")
  VALUE,
  @JsonNullValue
  NULL_VALUE
}
```

Not sure that code is acceptable, feature design is good etc. Need comments)