### PR TITLE
Fix private getter / setters on Boolean fields to support Kotlin

### DIFF
--- a/processor/src/main/java/com/bluelinelabs/logansquare/processor/JsonFieldHolder.java
+++ b/processor/src/main/java/com/bluelinelabs/logansquare/processor/JsonFieldHolder.java
@@ -78,7 +78,9 @@ public class JsonFieldHolder {
         possibleMethodNames.add("get" + elementNameLowerCase);
         if (elementTypeKind == TypeKind.BOOLEAN) {
             possibleMethodNames.add("is" + elementName);
+            possibleMethodNames.add("is" + elementNameLowerCase);
             possibleMethodNames.add("has" + elementName);
+            possibleMethodNames.add("has" + elementNameLowerCase);
             possibleMethodNames.add(elementNameLowerCase);
         }
 
@@ -120,6 +122,7 @@ public class JsonFieldHolder {
 
         List<String> possibleMethodNames = new ArrayList<>();
         possibleMethodNames.add("set" + elementName);
+        possibleMethodNames.add("set" + elementNameLowerCase);
 
         // Handle the case where variables are named in the form mVariableName instead of just variableName
         if (elementName.length() > 1 && elementName.charAt(0) == 'm' && (elementName.charAt(1) >= 'A' && elementName.charAt(1) <= 'Z')) {

--- a/processor/src/main/java/com/bluelinelabs/logansquare/processor/JsonFieldHolder.java
+++ b/processor/src/main/java/com/bluelinelabs/logansquare/processor/JsonFieldHolder.java
@@ -77,9 +77,8 @@ public class JsonFieldHolder {
         List<String> possibleMethodNames = new ArrayList<>();
         possibleMethodNames.add("get" + elementNameLowerCase);
         if (elementTypeKind == TypeKind.BOOLEAN) {
-            possibleMethodNames.add("is" + elementName);
+            possibleMethodNames.add(elementName);
             possibleMethodNames.add("is" + elementNameLowerCase);
-            possibleMethodNames.add("has" + elementName);
             possibleMethodNames.add("has" + elementNameLowerCase);
             possibleMethodNames.add(elementNameLowerCase);
         }
@@ -116,13 +115,17 @@ public class JsonFieldHolder {
 
     public static String getSetter(Element element, Elements elements) {
         TypeElement enclosingElement = (TypeElement) element.getEnclosingElement();
+        TypeKind elementTypeKind = element.asType().getKind();
 
         String elementName = element.getSimpleName().toString();
         String elementNameLowerCase = elementName.toLowerCase();
 
         List<String> possibleMethodNames = new ArrayList<>();
-        possibleMethodNames.add("set" + elementName);
         possibleMethodNames.add("set" + elementNameLowerCase);
+        
+        if (elementTypeKind == TypeKind.BOOLEAN && elementName.startsWith("is") && elementName.length() > 2) {
+            possibleMethodNames.add("set" + elementName.substring(2));
+        }
 
         // Handle the case where variables are named in the form mVariableName instead of just variableName
         if (elementName.length() > 1 && elementName.charAt(0) == 'm' && (elementName.charAt(1) >= 'A' && elementName.charAt(1) <= 'Z')) {

--- a/processor/src/main/java/com/bluelinelabs/logansquare/processor/JsonFieldHolder.java
+++ b/processor/src/main/java/com/bluelinelabs/logansquare/processor/JsonFieldHolder.java
@@ -77,8 +77,8 @@ public class JsonFieldHolder {
         List<String> possibleMethodNames = new ArrayList<>();
         possibleMethodNames.add("get" + elementNameLowerCase);
         if (elementTypeKind == TypeKind.BOOLEAN) {
-            possibleMethodNames.add("is" + elementNameLowerCase);
-            possibleMethodNames.add("has" + elementNameLowerCase);
+            possibleMethodNames.add("is" + elementName);
+            possibleMethodNames.add("has" + elementName);
             possibleMethodNames.add(elementNameLowerCase);
         }
 
@@ -119,7 +119,7 @@ public class JsonFieldHolder {
         String elementNameLowerCase = elementName.toLowerCase();
 
         List<String> possibleMethodNames = new ArrayList<>();
-        possibleMethodNames.add("set" + elementNameLowerCase);
+        possibleMethodNames.add("set" + elementName);
 
         // Handle the case where variables are named in the form mVariableName instead of just variableName
         if (elementName.length() > 1 && elementName.charAt(0) == 'm' && (elementName.charAt(1) >= 'A' && elementName.charAt(1) <= 'Z')) {


### PR DESCRIPTION
Kotlin classes that use `Boolean` types fail on compile. fixing them you have to define:
```kotlin
    @get:JvmName("isonlinePricingActive")
    @set:JvmName("setisOnlinePricingActive")
    var isOnlinePricingActive: Boolean = false,
```
A seperate getter/setter, which is lowercase. This does not work well with Kotlin. This file change fixes the issue by not using the `elementNameLowerCase` but instead uses `elementName` so we don't need the verbose annotation on any `Boolean` field.