### PR TITLE
Use model constructor when necessary (enables immutable models, encapsulation, Kotlin data classes etc)

### DIFF
--- a/processor/src/main/java/com/bluelinelabs/logansquare/processor/JsonObjectHolder.java
+++ b/processor/src/main/java/com/bluelinelabs/logansquare/processor/JsonObjectHolder.java
@@ -31,9 +31,12 @@ public class JsonObjectHolder {
     public String onCompleteCallback;
     public String preSerializeCallback;
 
+    public boolean needConstructorInjection;
+
     // Using a TreeMap now to keep the entries sorted. This ensures that code is
     // always written the exact same way, no matter which JDK you're using.
-    public final Map<String, JsonFieldHolder> fieldMap = new TreeMap<>();
+    public Map<String, JsonFieldHolder> fieldMap = new TreeMap<>();
+
     public boolean fileCreated;
 
     public boolean hasParentClass() {

--- a/processor/src/main/java/com/bluelinelabs/logansquare/processor/processor/JsonFieldProcessor.java
+++ b/processor/src/main/java/com/bluelinelabs/logansquare/processor/processor/JsonFieldProcessor.java
@@ -63,11 +63,14 @@ public class JsonFieldProcessor extends Processor {
         TypeElement enclosingElement = (TypeElement)element.getEnclosingElement();
 
         JsonObjectHolder objectHolder = jsonObjectMap.get(TypeUtils.getInjectedFQCN(enclosingElement, elements));
-        JsonFieldHolder fieldHolder = objectHolder.fieldMap.get(element.getSimpleName().toString());
+
+        String propertyName = element.getSimpleName().toString();
+
+        JsonFieldHolder fieldHolder = objectHolder.fieldMap.get(propertyName);
 
         if (fieldHolder == null) {
             fieldHolder = new JsonFieldHolder();
-            objectHolder.fieldMap.put(element.getSimpleName().toString(), fieldHolder);
+            objectHolder.fieldMap.put(propertyName, fieldHolder);
         }
 
         JsonField annotation = element.getAnnotation(JsonField.class);
@@ -102,8 +105,8 @@ public class JsonFieldProcessor extends Processor {
             return false;
         }
 
-        if (element.getModifiers().contains(PRIVATE) && (TextUtils.isEmpty(JsonFieldHolder.getGetter(element, elements)) || TextUtils.isEmpty(JsonFieldHolder.getSetter(element, elements)))) {
-            error(element, "@%s annotation can only be used on private fields if both getter and setter are present.", JsonField.class.getSimpleName());
+        if (element.getModifiers().contains(PRIVATE) && (TextUtils.isEmpty(JsonFieldHolder.getGetter(element, elements)))) {
+            error(element, "@%s annotation can only be used on private fields if a getter is present.", JsonField.class.getSimpleName());
             return false;
         }
 

--- a/processor/src/test/java/com/bluelinelabs/logansquare/processor/ConstructorInjectionTest.java
+++ b/processor/src/test/java/com/bluelinelabs/logansquare/processor/ConstructorInjectionTest.java
@@ -1,0 +1,29 @@
+package com.bluelinelabs.logansquare.processor;
+
+import com.google.testing.compile.JavaFileObjects;
+import org.junit.Test;
+
+import static com.google.common.truth.Truth.ASSERT;
+import static com.google.testing.compile.JavaSourceSubjectFactory.javaSource;
+
+public class ConstructorInjectionTest {
+    @Test
+    public void testPrivateFields() {
+        ASSERT.about(javaSource())
+                .that(JavaFileObjects.forResource("model/good/PrivateFieldsWithoutSettersModel.java"))
+                .processedWith(new JsonAnnotationProcessor())
+                .compilesWithoutError()
+                .and()
+                .generatesSources(JavaFileObjects.forResource("generated/PrivateFieldsWithoutSettersModel$$JsonObjectMapper.java"));
+    }
+
+    @Test
+    public void testImmutableFields() {
+        ASSERT.about(javaSource())
+                .that(JavaFileObjects.forResource("model/good/ImmutableFieldsModel.java"))
+                .processedWith(new JsonAnnotationProcessor())
+                .compilesWithoutError()
+                .and()
+                .generatesSources(JavaFileObjects.forResource("generated/ImmutableFieldsModel$$JsonObjectMapper.java"));
+    }
+}

--- a/processor/src/test/java/com/bluelinelabs/logansquare/processor/NegativeTests.java
+++ b/processor/src/test/java/com/bluelinelabs/logansquare/processor/NegativeTests.java
@@ -3,8 +3,12 @@ package com.bluelinelabs.logansquare.processor;
 import com.google.testing.compile.JavaFileObjects;
 import org.junit.Test;
 
+import javax.tools.JavaFileObject;
+import java.util.Arrays;
+
 import static com.google.common.truth.Truth.ASSERT;
 import static com.google.testing.compile.JavaSourceSubjectFactory.javaSource;
+import static com.google.testing.compile.JavaSourcesSubjectFactory.javaSources;
 
 public class NegativeTests {
 
@@ -23,7 +27,7 @@ public class NegativeTests {
                 .that(JavaFileObjects.forResource("model/bad/PrivateFieldModelWithoutAccessors.java"))
                 .processedWith(new JsonAnnotationProcessor())
                 .failsToCompile()
-                .withErrorContaining("@JsonField annotation can only be used on private fields if both getter and setter are present.");
+                .withErrorContaining("@JsonField annotation can only be used on private fields if a getter is present.");
     }
 
     @Test
@@ -33,6 +37,19 @@ public class NegativeTests {
                 .processedWith(new JsonAnnotationProcessor())
                 .failsToCompile()
                 .withErrorContaining("TypeConverter elements must implement the TypeConverter interface or extend from one of the convenience helpers");
+    }
+
+    @Test
+    public void inheritFromModelWithConstructorInjection() {
+        JavaFileObject badDescendant = JavaFileObjects.forResource("model/bad/ImmutableFieldsInheritanceModel.java");
+        JavaFileObject okParent = JavaFileObjects.forResource("model/good/ImmutableFieldsModel.java");
+
+        ASSERT.about(javaSources())
+                .that(Arrays.asList(okParent, badDescendant))
+                .processedWith(new JsonAnnotationProcessor())
+                .failsToCompile()
+                .withErrorContaining("Subclassing from models with constructor injection is not supported")
+                .in(badDescendant);
     }
 
     @Test

--- a/processor/src/test/resources/generated/ImmutableFieldsModel$$JsonObjectMapper.java
+++ b/processor/src/test/resources/generated/ImmutableFieldsModel$$JsonObjectMapper.java
@@ -1,0 +1,83 @@
+package com.bluelinelabs.logansquare.processor;
+
+import com.bluelinelabs.logansquare.JsonMapper;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import java.io.IOException;
+import java.lang.Integer;
+import java.lang.Override;
+import java.lang.String;
+import java.lang.SuppressWarnings;
+import java.lang.UnsupportedOperationException;
+import java.util.ArrayList;
+import java.util.List;
+
+@SuppressWarnings("unsafe,unchecked")
+public final class ImmutableFieldsModel$$JsonObjectMapper extends JsonMapper<ImmutableFieldsModel> {
+  @Override
+  public ImmutableFieldsModel parse(JsonParser jsonParser) throws IOException {
+    Integer integerField = null;
+    String[] arrayField = null;
+    Integer anotherField = null;
+    if (jsonParser.getCurrentToken() == null) {
+      jsonParser.nextToken();
+    }
+    if (jsonParser.getCurrentToken() != JsonToken.START_OBJECT) {
+      jsonParser.skipChildren();
+      return null;
+    }
+    while (jsonParser.nextToken() != JsonToken.END_OBJECT) {
+      String fieldName = jsonParser.getCurrentName();
+      jsonParser.nextToken();
+      if ("integerField".equals(fieldName)) {
+        integerField = jsonParser.getValueAsInt();
+      } else if ("arrayField".equals(fieldName)) {
+        if (jsonParser.getCurrentToken() == JsonToken.START_ARRAY) {
+          List<String> collection1 = new ArrayList<String>();
+          while (jsonParser.nextToken() != JsonToken.END_ARRAY) {
+            String value1;
+            value1 = jsonParser.getValueAsString(null);
+            collection1.add(value1);
+          }
+          String[] array = collection1.toArray(new String[collection1.size()]);
+          arrayField = array;
+        } else {
+          arrayField = null;
+        }
+      } else if ("anotherField".equals(fieldName)) {
+        anotherField = jsonParser.getValueAsInt();
+      }
+      jsonParser.skipChildren();
+    }
+    return new ImmutableFieldsModel(integerField, arrayField, anotherField);
+  }
+
+  @Override
+  public void parseField(ImmutableFieldsModel instance, String fieldName, JsonParser jsonParser) throws IOException {
+    throw new UnsupportedOperationException("The class is using constructor injection, individual fields can not be parsed");
+  }
+
+  @Override
+  public void serialize(ImmutableFieldsModel object, JsonGenerator jsonGenerator, boolean writeStartAndEnd) throws IOException {
+    if (writeStartAndEnd) {
+      jsonGenerator.writeStartObject();
+    }
+    jsonGenerator.writeNumberField("integerField", object.getIntegerField());
+    final String[] lslocalarrayField = object.getArrayField();
+    if (lslocalarrayField != null) {
+      jsonGenerator.writeFieldName("arrayField");
+      jsonGenerator.writeStartArray();
+      for (String element1 : lslocalarrayField) {
+        if (element1 != null) {
+          jsonGenerator.writeString(element1);
+        }
+      }
+      jsonGenerator.writeEndArray();
+    }
+    jsonGenerator.writeNumberField("anotherField", object.getAnotherField());
+    if (writeStartAndEnd) {
+      jsonGenerator.writeEndObject();
+    }
+  }
+}

--- a/processor/src/test/resources/generated/PrivateFieldsWithoutSettersModel$$JsonObjectMapper.java
+++ b/processor/src/test/resources/generated/PrivateFieldsWithoutSettersModel$$JsonObjectMapper.java
@@ -1,0 +1,83 @@
+package com.bluelinelabs.logansquare.processor;
+
+import com.bluelinelabs.logansquare.JsonMapper;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import java.io.IOException;
+import java.lang.Integer;
+import java.lang.Override;
+import java.lang.String;
+import java.lang.SuppressWarnings;
+import java.lang.UnsupportedOperationException;
+import java.util.ArrayList;
+import java.util.List;
+
+@SuppressWarnings("unsafe,unchecked")
+public final class PrivateFieldsWithoutSettersModel$$JsonObjectMapper extends JsonMapper<PrivateFieldsWithoutSettersModel> {
+  @Override
+  public PrivateFieldsWithoutSettersModel parse(JsonParser jsonParser) throws IOException {
+    Integer integerField = null;
+    String[] arrayField = null;
+    Integer anotherField = null;
+    if (jsonParser.getCurrentToken() == null) {
+      jsonParser.nextToken();
+    }
+    if (jsonParser.getCurrentToken() != JsonToken.START_OBJECT) {
+      jsonParser.skipChildren();
+      return null;
+    }
+    while (jsonParser.nextToken() != JsonToken.END_OBJECT) {
+      String fieldName = jsonParser.getCurrentName();
+      jsonParser.nextToken();
+      if ("integerField".equals(fieldName)) {
+        integerField = jsonParser.getValueAsInt();
+      } else if ("arrayField".equals(fieldName)) {
+        if (jsonParser.getCurrentToken() == JsonToken.START_ARRAY) {
+          List<String> collection1 = new ArrayList<String>();
+          while (jsonParser.nextToken() != JsonToken.END_ARRAY) {
+            String value1;
+            value1 = jsonParser.getValueAsString(null);
+            collection1.add(value1);
+          }
+          String[] array = collection1.toArray(new String[collection1.size()]);
+          arrayField = array;
+        } else {
+          arrayField = null;
+        }
+      } else if ("anotherField".equals(fieldName)) {
+        anotherField = jsonParser.getValueAsInt();
+      }
+      jsonParser.skipChildren();
+    }
+    return new PrivateFieldsWithoutSettersModel(integerField, arrayField, anotherField);
+  }
+
+  @Override
+  public void parseField(PrivateFieldsWithoutSettersModel instance, String fieldName, JsonParser jsonParser) throws IOException {
+    throw new UnsupportedOperationException("The class is using constructor injection, individual fields can not be parsed");
+  }
+
+  @Override
+  public void serialize(PrivateFieldsWithoutSettersModel object, JsonGenerator jsonGenerator, boolean writeStartAndEnd) throws IOException {
+    if (writeStartAndEnd) {
+      jsonGenerator.writeStartObject();
+    }
+    jsonGenerator.writeNumberField("integerField", object.getIntegerField());
+    final String[] lslocalarrayField = object.getArrayField();
+    if (lslocalarrayField != null) {
+      jsonGenerator.writeFieldName("arrayField");
+      jsonGenerator.writeStartArray();
+      for (String element1 : lslocalarrayField) {
+        if (element1 != null) {
+          jsonGenerator.writeString(element1);
+        }
+      }
+      jsonGenerator.writeEndArray();
+    }
+    jsonGenerator.writeNumberField("anotherField", object.getAnotherField());
+    if (writeStartAndEnd) {
+      jsonGenerator.writeEndObject();
+    }
+  }
+}

--- a/processor/src/test/resources/model/bad/ImmutableFieldsInheritanceModel.java
+++ b/processor/src/test/resources/model/bad/ImmutableFieldsInheritanceModel.java
@@ -1,0 +1,24 @@
+package com.bluelinelabs.logansquare.processor;
+
+import com.bluelinelabs.logansquare.annotation.JsonField;
+import com.bluelinelabs.logansquare.annotation.JsonObject;
+
+@JsonObject
+public final class ImmutableFieldsInheritanceModel extends ImmutableFieldsModel {
+    @JsonField
+    int i;
+
+    @JsonField
+    private String[] j;
+
+    @JsonField
+    int k;
+
+    public ImmutableFieldsInheritanceModel(int integerField, String[] whatever, int anotherField) {
+        super(integerField, whatever, anotherField);
+    }
+
+    public String[] getJ() {
+        return j;
+    }
+}

--- a/processor/src/test/resources/model/good/ImmutableFieldsModel.java
+++ b/processor/src/test/resources/model/good/ImmutableFieldsModel.java
@@ -1,0 +1,34 @@
+package com.bluelinelabs.logansquare.processor;
+
+import com.bluelinelabs.logansquare.annotation.JsonField;
+import com.bluelinelabs.logansquare.annotation.JsonObject;
+
+@JsonObject
+public class ImmutableFieldsModel {
+    @JsonField
+    final int integerField;
+
+    @JsonField
+    final String[] arrayField;
+
+    @JsonField
+    int anotherField;
+
+    public ImmutableFieldsModel(int integerField, String[] whatever, int anotherField) {
+        this.integerField = integerField;
+        this.arrayField = whatever;
+        this.anotherField = anotherField;
+    }
+
+    public String[] getArrayField() {
+        return arrayField;
+    }
+
+    public int getAnotherField() {
+        return anotherField;
+    }
+
+    public int getIntegerField() {
+        return integerField;
+    }
+}

--- a/processor/src/test/resources/model/good/PrivateFieldsWithoutSettersModel.java
+++ b/processor/src/test/resources/model/good/PrivateFieldsWithoutSettersModel.java
@@ -1,0 +1,42 @@
+package com.bluelinelabs.logansquare.processor;
+
+import com.bluelinelabs.logansquare.annotation.JsonField;
+import com.bluelinelabs.logansquare.annotation.JsonObject;
+
+@JsonObject
+public final class PrivateFieldsWithoutSettersModel {
+    @JsonField
+    int integerField;
+
+    @JsonField
+    String[] arrayField;
+
+    @JsonField
+    private int anotherField;
+
+    public PrivateFieldsWithoutSettersModel(int integerField, String[] whatever, int anotherField) {
+        this.integerField = integerField;
+        this.arrayField = whatever;
+        this.anotherField = anotherField;
+    }
+
+    public void setArrayField(String[] arrayField) {
+        this.arrayField = arrayField;
+    }
+
+    public void setIntegerField(int integerField) {
+        this.integerField = integerField;
+    }
+
+    public String[] getArrayField() {
+        return arrayField;
+    }
+
+    public int getAnotherField() {
+        return anotherField;
+    }
+
+    public int getIntegerField() {
+        return integerField;
+    }
+}


### PR DESCRIPTION
This pull request adds a fallback to non-default constructors for instantiating model class.

As of version 1.3.7 LoganSquare models are required to have either mutable public fields or public getter and setter:

    @JsonObject
    class Dto {
        @JsonField
        public String property1;

        @JsonField
        private int property2;

        public int getProperty2() { return property2; }

        public void setProperty2(int value) { this.property2 = value; }
    }

This rubs many "enterprise specialists" wrong way and makes LoganSquare incompatible with certain use cases (such as Kotlin data classes). In comparison, various reflection-based JSON libraries have no issues with classes like this:

    @JsonObject
    class ImmutableDto {
        @JsonField
        private final property;

        public ImmutableDto(String property) {
            this.property = property;
        }
    }

Those libraries typically use reflection to instantiate the class without calling constructor, then proceed to directly assign values to internal fields, (ab)using reflection conduct to disregard their private/final qualifiers.

Compared to those libraries, supporting non-default constructors in LoganSquare is slightly non-trivial due to it's compile-time nature.

In addition to using a constructor if assigning fields directly is impossible, this pull-request adds a check to forbid subclassing other models from models, that require constructor-based injection (subclassing in the opposite direction is harmless, so it is still allowed).